### PR TITLE
Initialize project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Porcana
+
+This repository contains a minimal skeleton for the Porcana project.
+
+## Stack
+
+- **Backend**: Python FastAPI with LangChain
+- **Frontend**: React with React Router v5 and Zustand
+- **Infrastructure**: Docker Compose
+
+## Development
+
+1. Build and start services:
+
+```bash
+docker-compose up --build
+```
+
+2. Access the API at `http://localhost:8000`.
+3. Access the frontend at `http://localhost:3000`.
+
+## License
+
+See [LICENSE](LICENSE).

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app/ ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import base64
+
+app = FastAPI(title="Porcana API")
+
+class Deck(BaseModel):
+    code: str
+
+@app.get("/")
+async def root():
+    return {"message": "Porcana backend"}
+
+@app.post("/decode")
+async def decode_deck(deck: Deck):
+    try:
+        decoded = base64.b64decode(deck.code).decode('utf-8')
+        return {"decoded": decoded}
+    except Exception:
+        return {"error": "Invalid deck code"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+langchain
+pydantic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+COPY webpack.config.js ./
+COPY .babelrc ./
+COPY public ./public
+COPY src ./src
+RUN npm install
+RUN npm run build
+CMD ["npx", "serve", "-s", "dist"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "porcana-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-router-dom": "^5.3.0",
+    "zustand": "^4.3.7"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Porcana</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import create from 'zustand';
+
+const useStore = create(set => ({ count: 0, inc: () => set(state => ({ count: state.count + 1 })) }));
+
+function Home() {
+  const { count, inc } = useStore();
+  return (
+    <div>
+      <h1>Porcana Frontend</h1>
+      <p>Count: {count}</p>
+      <button onClick={inc}>Increment</button>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <Router>
+      <Switch>
+        <Route path="/" component={Home} />
+      </Switch>
+    </Router>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,30 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/',
+  },
+  devServer: {
+    historyApiFallback: true,
+    port: 3000,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: 'babel-loader',
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  plugins: [
+    new HtmlWebpackPlugin({ template: './public/index.html' }),
+  ],
+};


### PR DESCRIPTION
## Summary
- set up project with backend and frontend directories
- add FastAPI backend with simple deck decoding endpoint
- add React frontend using React Router v5 and Zustand
- add Docker Compose configuration for the project

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68595512a1c88326a9fa6edef3b07856