### PR TITLE
포트폴리오와 자산 daily return 에 가상의 가격 추가

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -8,9 +8,11 @@
 .claude/
 ├── skills/              # 참고 자료 및 간단한 작업
 │   ├── api-conventions/     # API 설계 패턴
+│   ├── api-specs/           # API 엔드포인트 상세 스펙
+│   ├── entity-reference/    # Core Entity 구조
+│   ├── portfolio-domain/    # 포트폴리오 수익률 추적
 │   ├── batch-jobs/          # 배치 작업 레퍼런스
 │   ├── arena-specs/         # Arena 알고리즘 상세
-│   ├── entity-reference/    # Entity 구조 참고
 │   └── test-patterns/       # 테스트 작성 패턴
 │
 ├── agents/              # 복잡한 독립 작업
@@ -93,10 +95,10 @@ Arena 관련 작업 시 자동으로 참조합니다.
 ---
 
 ### 4. entity-reference
-**설명**: Entity 구조 및 관계 참고 자료
+**설명**: Core Entity 구조 및 관계 참고 자료
 
 **사용 시기**:
-- Entity 구조 확인할 때
+- Entity 기본 구조 확인할 때
 - 테이블 관계 파악할 때
 - 새로운 Entity 추가할 때
 
@@ -108,12 +110,42 @@ Entity 관련 작업 시 자동으로 참조합니다.
 **주요 내용**:
 - Core Entities (Asset, Portfolio, User, ArenaSession 등)
 - Enum 정의 (Market, Sector, AssetClass 등)
-- 관계 및 제약 조건
+- 기본 관계 및 제약 조건
 - XOR 소유권 패턴
 
 ---
 
-### 5. test-patterns
+### 5. portfolio-domain
+**설명**: 포트폴리오 수익률 추적 심화 (Snapshot, DailyReturn, weightUsed)
+
+**사용 시기**:
+- 포트폴리오 수익률 계산 로직 작업할 때
+- weightUsed(시가총액 기반 동적 비중) 이해할 때
+- PortfolioSnapshot, SnapshotAssetDailyReturn 구조 확인할 때
+- 배치 수익률 계산 로직 수정할 때
+
+**호출 방법**:
+```
+포트폴리오 수익률 관련 작업 시 자동으로 참조합니다.
+```
+
+**주요 내용**:
+- PortfolioSnapshot, PortfolioSnapshotAsset (리밸런싱 이력)
+- PortfolioDailyReturn, SnapshotAssetDailyReturn
+- **weightUsed**: 시가총액 기반 동적 비중 (❌ 고정 → ✅ 동적)
+- Two-Pass 비중 계산 로직
+- 환율 효과 분리 (로컬 수익률 + 환율 수익률)
+- API에서 최신 weightUsed 조회 방법
+
+**핵심 차이점**:
+```
+초기 비중: PortfolioSnapshotAsset.weight (고정)
+현재 비중: SnapshotAssetDailyReturn.weightUsed (동적, 매일 변함)
+```
+
+---
+
+### 6. test-patterns
 **설명**: 테스트 작성 패턴 및 컨벤션
 
 **사용 시기**:

--- a/.claude/skills/batch-jobs/SKILL.md
+++ b/.claude/skills/batch-jobs/SKILL.md
@@ -57,12 +57,27 @@ disable-model-invocation: false
 ./gradlew bootRun --args='--spring.batch.job.names=krEtfDailyPriceJob'
 ```
 
+**19:00 KST (매일) - 포트폴리오 수익률 계산**
+```bash
+# 포트폴리오 일별 수익률 계산
+./gradlew bootRun --args='--spring.batch.job.names=portfolioPerformanceJob'
+```
+
 ## 특수 배치 Job
 
 **US 이미지 업데이트 (수동 실행)**
 ```bash
 # 미국 주식 이미지 URL 업데이트
 ./gradlew bootRun --args='--spring.batch.job.names=usImageUpdateJob'
+```
+
+**포트폴리오 비중 재계산 (일회성 수동 실행)**
+```bash
+# application.yml에서 enabled=true 설정 후 실행
+# 또는 환경변수로 활성화
+RECALCULATE_WEIGHT_USED_ENABLED=true ./gradlew bootRun
+
+# 기존 SnapshotAssetDailyReturn의 weightUsed를 시가총액 기반으로 재계산
 ```
 
 ## Batch Job 구조 패턴
@@ -122,9 +137,136 @@ public void runKrDailyPriceUpdate()
 public void runUsDailyPriceUpdate()
 ```
 
+## 포트폴리오 수익률 계산 (Portfolio Performance Batch)
+
+### 목적
+- ACTIVE 상태 포트폴리오의 일별 수익률 계산
+- 시가총액 기반 동적 비중 계산 및 저장
+- 환율 효과 분리 추적 (로컬 수익률 vs 환율 수익률)
+
+### 계산 로직
+
+**1. 적용 스냅샷 찾기**
+```java
+// effectiveDate <= targetDate 중 가장 최근 스냅샷 사용
+PortfolioSnapshot snapshot = findFirstByPortfolioIdAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+    portfolioId, targetDate
+);
+```
+
+**2. 시가총액 기반 비중 계산**
+```java
+// First pass: 현재 평가금액 계산
+for (각 자산) {
+    초기비중 = snapshotAsset.getWeight();  // 예: 10.0%
+    현재평가금액 = 초기비중 × (1 + 수익률/100);
+    전체평가금액 += 현재평가금액;
+}
+
+// Second pass: 정규화된 비중 계산
+for (각 자산) {
+    현재비중 = (현재평가금액 / 전체평가금액) × 100;
+    // SnapshotAssetDailyReturn.weightUsed에 저장
+}
+```
+
+**예시:**
+- 삼성전자: 초기 10%, 수익률 +20% → 현재 평가 12 → 현재 비중 약 11%
+- 카카오: 초기 10%, 수익률 -10% → 현재 평가 9 → 현재 비중 약 9%
+
+**3. 환율 효과 분리**
+```java
+// 미국 자산의 경우
+assetReturnTotal = assetReturnLocal + fxReturn
+
+// 한국 자산의 경우
+fxReturn = 0
+assetReturnTotal = assetReturnLocal
+```
+
+### 저장 데이터
+
+**PortfolioDailyReturn (포트폴리오 전체)**
+- `return_total`: 전체 수익률 (%)
+- `return_local`: 로컬 가격 변동 수익률 (%)
+- `return_fx`: 환율 변동 수익률 (%)
+
+**SnapshotAssetDailyReturn (자산별)**
+- `weight_used`: **시가총액 기반 동적 비중** (%)
+- `asset_return_local`: 자산 로컬 수익률 (%)
+- `asset_return_total`: 자산 전체 수익률 (%)
+- `fx_return`: 환율 수익률 (%)
+- `contribution_total`: 포트폴리오 수익률 기여도 (%)
+
+### 중요 포인트
+
+**weightUsed의 의미:**
+- ❌ **이전**: 스냅샷의 고정 비중을 그대로 복사 (시간이 지나도 변하지 않음)
+- ✅ **현재**: 시가총액 기반 동적 비중 (가격 변동에 따라 자동 조정)
+
+**API에서 사용:**
+```java
+// HomeService, PortfolioService
+// 최신 weightUsed를 조회하여 현재 비중 표시
+Optional<SnapshotAssetDailyReturn> latest =
+    findFirstByPortfolioIdAndAssetIdOrderByReturnDateDesc(portfolioId, assetId);
+Double currentWeight = latest.get().getWeightUsed();
+```
+
+## 포트폴리오 비중 재계산 (Recalculate Weight Used)
+
+### 목적
+기존에 잘못 계산된 `weightUsed` 데이터를 시가총액 기반으로 재계산
+
+### 사용법
+```bash
+# 방법 1: 환경변수 사용 (권장)
+RECALCULATE_WEIGHT_USED_ENABLED=true ./gradlew bootRun
+
+# 방법 2: application.yml 수정
+# batch.runner.recalculate-weight-used.enabled: true 설정 후
+./gradlew bootRun
+```
+
+### 설정
+```yaml
+# application.yml
+batch:
+  runner:
+    recalculate-weight-used:
+      enabled: false  # 기본값: false (비활성화)
+```
+
+### 처리 흐름
+```
+1. 모든 포트폴리오 조회
+2. 각 포트폴리오에 대해:
+   ├─ 모든 SnapshotAssetDailyReturn 조회 (날짜순)
+   ├─ 날짜별로 그룹핑
+   └─ 각 날짜에 대해 시가총액 기반 비중 재계산
+3. Reflection을 사용하여 weightUsed 필드 업데이트
+```
+
+### 로그 예시
+```
+[1/15] Processing portfolio: My Portfolio (uuid-123)
+  ✓ Recalculated 45 daily returns
+[2/15] Processing portfolio: Test Portfolio (uuid-456)
+  ✓ Recalculated 30 daily returns
+...
+========================================
+WeightUsed Recalculation completed
+Total portfolios: 15
+Successfully processed: 15
+Failed: 0
+Total daily returns recalculated: 675
+========================================
+```
+
 ## 공통 처리 원칙
 
 - **Upsert 전략**: symbol + market을 natural key로 사용
 - **as_of 관리**: 배치 실행일을 기록
 - **active 플래그**: 유니버스 포함 종목만 true
 - **이력 관리**: as_of 기준으로 과거 데이터 조회 가능
+- **동적 비중**: weightUsed는 시가총액 기반으로 매일 자동 조정

--- a/.claude/skills/entity-reference/SKILL.md
+++ b/.claude/skills/entity-reference/SKILL.md
@@ -201,30 +201,35 @@ public class Portfolio {
 
 **Check Constraint**: `(userId IS NULL XOR guestSessionId IS NULL)`
 
-### PortfolioPosition (포지션)
+### PortfolioAsset (포트폴리오 자산)
 
-포트폴리오 내 자산 비중
+포트폴리오 내 자산 구성
 
 ```java
 @Entity
-@Table(name = "portfolio_positions")
-public class PortfolioPosition {
+@Table(name = "portfolio_assets")
+public class PortfolioAsset {
     @Id
     private UUID id;
 
-    @ManyToOne
-    private Portfolio portfolio;
+    private UUID portfolioId;
+    private UUID assetId;
 
-    @ManyToOne
-    private Asset asset;
-
+    /**
+     * 초기 설정 비중 (%)
+     * ⚠️ 실제 현재 비중은 SnapshotAssetDailyReturn.weightUsed 참조
+     */
     private BigDecimal weightPct;  // 0-100
 
-    private LocalDateTime createdAt;
+    private LocalDateTime addedAt;
 }
 ```
 
 **Unique Index**: `(portfolio_id, asset_id)`
+
+**중요:**
+- `weightPct`는 초기 설정 비중 (고정값)
+- **실제 현재 비중**은 `portfolio-domain` skill 참조 → `SnapshotAssetDailyReturn.weightUsed`
 
 ### ArenaSession (아레나 세션)
 
@@ -307,13 +312,16 @@ public class ArenaRound {
 ```
 User 1 --- * Portfolio (mainPortfolioId)
 GuestSession 1 --- * Portfolio
-Portfolio 1 --- * PortfolioPosition
+Portfolio 1 --- * PortfolioAsset
 Portfolio 1 --- 1 ArenaSession
-Asset 1 --- * PortfolioPosition
+Asset 1 --- * PortfolioAsset
 Asset 1 --- * AssetPrice
 Asset 1 --- * AssetRiskHistory
 ArenaSession 1 --- * ArenaRound
 ```
+
+**포트폴리오 수익률 추적:**
+- `PortfolioSnapshot`, `SnapshotAssetDailyReturn` 등은 `portfolio-domain` skill 참조
 
 ## Key Constraints
 
@@ -323,5 +331,11 @@ ArenaSession 1 --- * ArenaRound
    - `(asset_id, price_date)` - AssetPrice
    - `(asset_id, week)` - AssetRiskHistory
    - `(currency_code, exchange_date)` - ExchangeRate
-   - `(portfolio_id, asset_id)` - PortfolioPosition
+   - `(portfolio_id, asset_id)` - PortfolioAsset
 3. **Guest Limits**: 게스트당 최대 3개 포트폴리오
+
+## Related Skills
+
+- **portfolio-domain**: 포트폴리오 수익률 추적, 스냅샷, 일별 리턴 엔티티 상세
+- **arena-specs**: Arena 드래프트 알고리즘 및 추천 로직
+- **batch-jobs**: 배치 작업 및 스케줄링

--- a/.claude/skills/portfolio-domain/SKILL.md
+++ b/.claude/skills/portfolio-domain/SKILL.md
@@ -1,0 +1,413 @@
+---
+name: portfolio-domain
+description: Portfolio domain deep dive - snapshots, daily returns, performance calculation. Use when working with portfolio performance tracking.
+disable-model-invocation: false
+---
+
+# Portfolio Domain - 포트폴리오 수익률 추적
+
+## Overview
+
+포트폴리오의 수익률을 시간에 따라 추적하기 위한 엔티티 및 로직 설명
+
+**핵심 개념:**
+- **Snapshot**: 특정 시점의 포트폴리오 구성 (리밸런싱 이력)
+- **DailyReturn**: 일별 수익률 계산 결과
+- **weightUsed**: 시가총액 기반 동적 비중 (시간에 따라 변함)
+
+## Core Entities
+
+### PortfolioSnapshot (포트폴리오 스냅샷)
+
+특정 시점의 포트폴리오 자산 구성을 기록 (리밸런싱 이력)
+
+```java
+@Entity
+@Table(name = "portfolio_snapshots")
+public class PortfolioSnapshot {
+    @Id
+    private UUID id;
+
+    private UUID portfolioId;
+
+    /**
+     * 스냅샷 유효 시작일
+     * 이 날짜부터 다음 스냅샷 전까지 이 구성이 유효함
+     */
+    private LocalDate effectiveDate;
+
+    /**
+     * 스냅샷 메모 (예: "Initial creation", "Rebalancing" 등)
+     */
+    private String note;
+
+    private LocalDateTime createdAt;
+}
+```
+
+**Unique Index**: `(portfolio_id, effective_date)`
+
+**사용 시나리오:**
+1. 포트폴리오 생성 시 → 초기 스냅샷 생성
+2. 사용자가 비중 리밸런싱 → 새 스냅샷 생성
+3. 수익률 계산 시 → `effectiveDate <= targetDate` 중 가장 최근 스냅샷 사용
+
+### PortfolioSnapshotAsset (스냅샷 자산 구성)
+
+특정 스냅샷 시점의 자산별 비중 정보
+
+```java
+@Entity
+@Table(name = "portfolio_snapshot_assets")
+public class PortfolioSnapshotAsset {
+    @Id
+    private UUID id;
+
+    private UUID snapshotId;
+    private UUID assetId;
+
+    /**
+     * 자산 비중 (%)
+     * 예: 25.0 = 25%
+     * ⚠️ 이것은 초기 설정 비중 (고정값)
+     */
+    private BigDecimal weight;  // 초기 비중
+}
+```
+
+**Unique Index**: `(snapshot_id, asset_id)`
+
+**중요:**
+- `weight`는 **스냅샷 생성 시점의 초기 비중** (고정)
+- 시간이 지나면서 가격 변동으로 실제 비중은 변함
+- **실제 현재 비중**은 `SnapshotAssetDailyReturn.weightUsed`에서 조회
+
+### PortfolioDailyReturn (포트폴리오 일별 수익률)
+
+포트폴리오 전체의 일별 수익률 기록
+
+```java
+@Entity
+@Table(name = "portfolio_daily_returns")
+public class PortfolioDailyReturn {
+    @Id
+    private UUID id;
+
+    private UUID portfolioId;
+    private UUID snapshotId;  // 적용된 스냅샷
+    private LocalDate returnDate;
+
+    /**
+     * 전체 수익률 (%)
+     * return_total = return_local + return_fx
+     */
+    private BigDecimal returnTotal;
+
+    /**
+     * 로컬 가격 변동 수익률 (%)
+     * 자산의 현지 통화 기준 가격 변동
+     */
+    private BigDecimal returnLocal;
+
+    /**
+     * 환율 수익률 (%)
+     * 외화 자산의 환율 변동 효과
+     */
+    private BigDecimal returnFx;
+
+    /**
+     * 포트폴리오 전체 평가금액 (원화 기준)
+     * 기준: 초기 10,000,000원 투자 가정
+     * 예: 10,000,000 × (1 + 0.02) = 10,200,000원
+     */
+    private BigDecimal totalValueKrw;
+
+    private LocalDateTime calculatedAt;
+}
+```
+
+**Unique Index**: `(portfolio_id, return_date)`
+
+**계산 예시:**
+```
+삼성전자 (KR): 로컬 +2%, 환율 0% → 전체 +2%
+애플 (US): 로컬 +3%, 환율 +1% → 전체 +4%
+포트폴리오: 가중평균 → return_total
+```
+
+### SnapshotAssetDailyReturn (자산별 일별 수익률)
+
+포트폴리오 내 각 자산의 일별 수익률 및 **현재 비중** 기록
+
+```java
+@Entity
+@Table(name = "snapshot_asset_daily_returns")
+public class SnapshotAssetDailyReturn {
+    @Id
+    private UUID id;
+
+    private UUID portfolioId;
+    private UUID snapshotId;
+    private UUID assetId;
+    private LocalDate returnDate;
+
+    /**
+     * 🔥 사용된 자산 비중 (%) - 시가총액 기반 동적 비중
+     * ⚠️ 이것이 실제 현재 비중! (가격 변동에 따라 매일 변함)
+     */
+    private BigDecimal weightUsed;
+
+    /**
+     * 자산 로컬 수익률 (%)
+     * 자산의 현지 통화 기준 가격 변동률
+     */
+    private BigDecimal assetReturnLocal;
+
+    /**
+     * 자산 전체 수익률 (%)
+     * asset_return_total = asset_return_local + fx_return
+     */
+    private BigDecimal assetReturnTotal;
+
+    /**
+     * 환율 수익률 (%)
+     * 외화 자산의 환율 변동 효과 (KRW 자산은 0)
+     */
+    private BigDecimal fxReturn;
+
+    /**
+     * 포트폴리오 전체 수익률에 대한 기여도 (%)
+     * contribution_total = asset_return_total * initialWeight / 100
+     */
+    private BigDecimal contributionTotal;
+
+    /**
+     * 자산 평가금액 (원화 기준)
+     * 초기 비중 × 초기 투자금 × (1 + 수익률)
+     * 예: 10% × 10,000,000원 × 1.20 = 1,200,000원
+     */
+    private BigDecimal valueKrw;
+
+    private LocalDateTime calculatedAt;
+}
+```
+
+**Unique Index**: `(portfolio_id, snapshot_id, asset_id, return_date)`
+
+## weightUsed의 의미 🔥
+
+### ❌ 이전 (잘못된 구현)
+```java
+// 스냅샷의 고정 비중을 그대로 복사
+BigDecimal weight = snapshotAsset.getWeight();
+```
+- 시간이 지나도 비중이 변하지 않음
+- 실제 시장 가치 반영 안 됨
+
+### ✅ 현재 (올바른 구현 - 금액 기반)
+```java
+// 금액 기반 계산 → 비중 자동 산출
+초기 투자금 = 10,000,000원
+초기 비중 = 10%
+초기 금액 = 10,000,000 × 0.10 = 1,000,000원
+
+수익률 = +20%
+현재 평가금액 = 1,000,000 × 1.20 = 1,200,000원 (valueKrw)
+
+전체 평가금액 = 모든 자산 valueKrw 합계 (totalValueKrw)
+현재 비중 = (1,200,000 / totalValueKrw) × 100 (weightUsed)
+```
+
+### 계산 예시
+
+**포트폴리오 초기 구성:**
+- 삼성전자: 10%
+- 카카오: 10%
+- 나머지: 80%
+
+**1일 후:**
+- 삼성전자: 수익률 +20% → 평가금액 12 → **현재 비중 약 11%**
+- 카카오: 수익률 -10% → 평가금액 9 → **현재 비중 약 9%**
+
+**결과:**
+- API에서 조회 시 → 삼성 11%, 카카오 9%
+- 수익률과 함께 실시간 비중 변화 확인 가능
+
+## 수익률 계산 로직 (Batch)
+
+### 1. 적용 스냅샷 찾기
+
+```java
+// effectiveDate <= targetDate 중 가장 최근 스냅샷 사용
+PortfolioSnapshot snapshot =
+    findFirstByPortfolioIdAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+        portfolioId, targetDate
+    );
+LocalDate snapshotDate = snapshot.getEffectiveDate();
+```
+
+### 2. 금액 기반 비중 계산 (Two-Pass)
+
+```java
+// 초기 가상 투자금
+private static final BigDecimal INITIAL_INVESTMENT_KRW = new BigDecimal("10000000.00");
+
+// First pass: 자산별 현재 평가금액 계산 (KRW)
+BigDecimal totalCurrentValueKrw = BigDecimal.ZERO;
+Map<UUID, BigDecimal> valueKrwMap = new HashMap<>();
+
+for (각 자산) {
+    초기비중 = snapshotAsset.getWeight();  // 예: 10.0%
+    수익률 = calculateAssetReturn(asset, snapshotDate, targetDate);
+
+    // 초기 투자 금액 계산
+    초기금액 = INITIAL_INVESTMENT_KRW × (초기비중 / 100);  // 1,000,000원
+
+    // 현재 평가금액 계산
+    현재평가금액 = 초기금액 × (1 + 수익률/100);  // 1,200,000원
+
+    valueKrwMap.put(assetId, 현재평가금액);
+    totalCurrentValueKrw += 현재평가금액;
+}
+
+// Second pass: 비중 자동 계산 및 저장
+for (각 자산) {
+    valueKrw = valueKrwMap.get(assetId);  // 1,200,000원
+    weightUsed = (valueKrw / totalCurrentValueKrw) × 100;  // 비중 자동 산출
+
+    // SnapshotAssetDailyReturn에 weightUsed, valueKrw 모두 저장 ✅
+}
+
+// PortfolioDailyReturn에 totalValueKrw 저장 ✅
+```
+
+### 3. 환율 효과 분리
+
+```java
+// 미국 자산의 경우
+assetReturnLocal = (targetPrice - startPrice) / startPrice × 100
+fxReturn = (targetRate - startRate) / startRate × 100
+assetReturnTotal = assetReturnLocal + fxReturn
+
+// 한국 자산의 경우
+fxReturn = 0
+assetReturnTotal = assetReturnLocal
+```
+
+## API에서 사용
+
+### HomeService, PortfolioService
+
+```java
+/**
+ * Get latest market-cap based weights for assets
+ * Returns the most recent weightUsed from SnapshotAssetDailyReturn
+ */
+private Map<UUID, Double> getLatestWeights(UUID portfolioId, Set<UUID> assetIds) {
+    Map<UUID, Double> weights = new HashMap<>();
+
+    for (UUID assetId : assetIds) {
+        snapshotAssetDailyReturnRepository
+            .findFirstByPortfolioIdAndAssetIdOrderByReturnDateDesc(portfolioId, assetId)
+            .ifPresent(dailyReturn ->
+                weights.put(assetId, dailyReturn.getWeightUsed().doubleValue())
+            );
+    }
+
+    return weights;
+}
+```
+
+**사용:**
+```java
+// 최신 weightUsed 조회, 없으면 초기 비중 사용
+Double weightPct = latestWeights.getOrDefault(
+    pa.getAssetId(),
+    pa.getWeightPct().doubleValue()
+);
+```
+
+## Entity Relationships
+
+```
+Portfolio 1 --- * PortfolioSnapshot
+PortfolioSnapshot 1 --- * PortfolioSnapshotAsset
+PortfolioSnapshot 1 --- * PortfolioDailyReturn
+PortfolioSnapshot 1 --- * SnapshotAssetDailyReturn
+
+Asset 1 --- * PortfolioSnapshotAsset
+Asset 1 --- * SnapshotAssetDailyReturn
+```
+
+## Data Flow (수익률 계산)
+
+```
+1. 포트폴리오 생성
+   └─> PortfolioSnapshot 생성 (effectiveDate = startedAt)
+       └─> PortfolioSnapshotAsset 생성 (초기 비중)
+
+2. 배치 실행 (매일 19:00)
+   ├─> 적용 스냅샷 찾기
+   ├─> 자산별 수익률 계산
+   ├─> 시가총액 기반 비중 계산
+   ├─> SnapshotAssetDailyReturn 저장 (weightUsed ✅)
+   └─> PortfolioDailyReturn 저장
+
+3. API 조회
+   ├─> 최신 SnapshotAssetDailyReturn 조회
+   └─> weightUsed를 현재 비중으로 표시
+```
+
+## Rebalancing (리밸런싱)
+
+사용자가 수동으로 비중을 조정할 경우:
+
+```
+1. 사용자가 비중 변경 요청
+   └─> PortfolioAsset.weightPct 업데이트 (기존 테이블)
+
+2. 새 PortfolioSnapshot 생성
+   ├─> effectiveDate = today
+   ├─> note = "Portfolio rebalancing"
+   └─> PortfolioSnapshotAsset 생성 (새 비중)
+
+3. 이후 배치 실행
+   └─> 새 스냅샷 기준으로 수익률 계산
+```
+
+## Key Points 요약
+
+1. **금액 기반 계산 (가장 중요) 💰:**
+   - 초기 투자금: **10,000,000원** 가정
+   - `valueKrw`: 자산 평가금액 (원화) - 실제 금액
+   - `totalValueKrw`: 포트폴리오 전체 평가금액 (원화)
+   - `weightUsed`: 금액 기반으로 자동 계산된 비중 (%)
+
+2. **두 종류의 비중:**
+   - `PortfolioSnapshotAsset.weight`: 초기 설정 비중 (고정, %)
+   - `SnapshotAssetDailyReturn.weightUsed`: 금액 기반 동적 비중 (매일 변함, %) ✅
+
+3. **계산 흐름:**
+   ```
+   초기 비중(%) → 초기 금액(KRW) → 수익률 적용 → 현재 금액(KRW) → 현재 비중(%)
+   ```
+
+4. **API는 weightUsed 사용:**
+   - 최신 weightUsed를 조회하여 현재 비중 표시
+   - 가격 변동에 따른 실시간 비중 변화 반영
+
+5. **배치는 Two-Pass 계산:**
+   - First: 금액 계산 (valueKrw, totalValueKrw)
+   - Second: 비중 자동 산출 (weightUsed)
+
+6. **환율 효과 분리:**
+   - 로컬 수익률 + 환율 수익률 = 전체 수익률
+   - 환율 변동의 영향을 명확히 추적
+
+7. **스냅샷 기반 이력 관리:**
+   - 리밸런싱 이력 추적 가능
+   - 과거 특정 시점의 구성 확인 가능
+
+8. **확장성:**
+   - 실제 거래 기능 추가 시 금액 필드 바로 활용 가능
+   - 사용자별 초기 투자금 커스터마이징 가능

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,12 +319,21 @@ w = riskWeight × sectorWeight × typeWeight × diversityPenalty
 
 ## 참고 자료
 
-### Skills (자동 로드되는 참고 자료)
+### Skills (도메인별 참고 자료)
+
+**API & Conventions:**
 - `api-conventions` - API 설계 패턴 및 컨벤션
 - `api-specs` - API 엔드포인트 상세 스펙
-- `entity-reference` - Entity 구조 및 관계
+
+**Domain Models:**
+- `entity-reference` - Core Entity 구조 및 관계
+- `portfolio-domain` - 포트폴리오 수익률 추적 (Snapshot, DailyReturn, weightUsed)
+
+**Business Logic:**
+- `arena-specs` - Arena 드래프트 알고리즘
 - `batch-jobs` - Spring Batch 작업 레퍼런스
-- `arena-specs` - Arena 알고리즘 상세
+
+**Testing:**
 - `test-patterns` - 테스트 작성 패턴
 
 ### Subagents (특수 작업용 AI 어시스턴트)

--- a/src/main/java/com/porcana/batch/job/PortfolioPerformanceBatchJob.java
+++ b/src/main/java/com/porcana/batch/job/PortfolioPerformanceBatchJob.java
@@ -271,9 +271,12 @@ public class PortfolioPerformanceBatchJob {
 
             // Calculate current weight based on market value (KRW)
             // 예: 1,200,000 / 11,000,000 × 100 = 10.91%
-            BigDecimal currentWeight = valueKrw
-                    .divide(totalCurrentValueKrw, 6, RoundingMode.HALF_UP)
-                    .multiply(BigDecimal.valueOf(100));
+            BigDecimal currentWeight = calc.initialWeight;
+            if (totalCurrentValueKrw.compareTo(BigDecimal.ZERO) > 0) {
+                currentWeight = valueKrw
+                        .divide(totalCurrentValueKrw, 6, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100));
+            }
 
             // Calculate contribution to portfolio return using initial weight
             BigDecimal contributionTotal = calc.result.assetReturnTotal

--- a/src/main/java/com/porcana/batch/runner/RecalculateWeightUsedRunner.java
+++ b/src/main/java/com/porcana/batch/runner/RecalculateWeightUsedRunner.java
@@ -1,0 +1,215 @@
+package com.porcana.batch.runner;
+
+import com.porcana.domain.portfolio.entity.Portfolio;
+import com.porcana.domain.portfolio.entity.PortfolioSnapshot;
+import com.porcana.domain.portfolio.entity.PortfolioSnapshotAsset;
+import com.porcana.domain.portfolio.entity.SnapshotAssetDailyReturn;
+import com.porcana.domain.portfolio.repository.PortfolioRepository;
+import com.porcana.domain.portfolio.repository.PortfolioSnapshotAssetRepository;
+import com.porcana.domain.portfolio.repository.PortfolioSnapshotRepository;
+import com.porcana.domain.portfolio.repository.SnapshotAssetDailyReturnRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * ApplicationRunner for recalculating weightUsed in SnapshotAssetDailyReturn
+ *
+ * This runner recalculates the weightUsed field to reflect market-cap based weights
+ * instead of fixed snapshot weights.
+ *
+ * Usage: Set batch.runner.recalculate-weight-used.enabled=true in application.yml
+ * Default: false (disabled)
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(
+        prefix = "batch.runner.recalculate-weight-used",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
+@RequiredArgsConstructor
+public class RecalculateWeightUsedRunner implements ApplicationRunner {
+
+    private final PortfolioRepository portfolioRepository;
+    private final SnapshotAssetDailyReturnRepository snapshotAssetDailyReturnRepository;
+    private final PortfolioSnapshotRepository portfolioSnapshotRepository;
+    private final PortfolioSnapshotAssetRepository portfolioSnapshotAssetRepository;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        log.info("========================================");
+        log.info("Starting WeightUsed Recalculation Runner");
+        log.info("========================================");
+
+        // Get all portfolios
+        List<Portfolio> portfolios = portfolioRepository.findAll();
+        log.info("Found {} portfolios to process", portfolios.size());
+
+        if (portfolios.isEmpty()) {
+            log.info("No portfolios to process. Exiting.");
+            return;
+        }
+
+        int totalProcessed = 0;
+        int totalFailed = 0;
+
+        for (int i = 0; i < portfolios.size(); i++) {
+            Portfolio portfolio = portfolios.get(i);
+            log.info("[{}/{}] Processing portfolio: {} ({})",
+                    i + 1, portfolios.size(), portfolio.getName(), portfolio.getId());
+
+            try {
+                int processed = recalculatePortfolioWeights(portfolio);
+                totalProcessed += processed;
+                log.info("  ✓ Recalculated {} daily returns", processed);
+            } catch (Exception e) {
+                totalFailed++;
+                log.error("  ✗ Failed to recalculate portfolio {}: {}",
+                        portfolio.getId(), e.getMessage(), e);
+            }
+        }
+
+        log.info("========================================");
+        log.info("WeightUsed Recalculation completed");
+        log.info("Total portfolios: {}", portfolios.size());
+        log.info("Successfully processed: {}", portfolios.size() - totalFailed);
+        log.info("Failed: {}", totalFailed);
+        log.info("Total daily returns recalculated: {}", totalProcessed);
+        log.info("========================================");
+    }
+
+    /**
+     * Recalculate market-cap based weights for a single portfolio
+     *
+     * @param portfolio Portfolio to recalculate
+     * @return Number of daily returns recalculated
+     */
+    @Transactional
+    protected int recalculatePortfolioWeights(Portfolio portfolio) {
+        UUID portfolioId = portfolio.getId();
+
+        // Get all asset daily returns for this portfolio, ordered by date
+        List<SnapshotAssetDailyReturn> allReturns = snapshotAssetDailyReturnRepository
+                .findByPortfolioIdOrderByReturnDateAsc(portfolioId);
+
+        if (allReturns.isEmpty()) {
+            log.debug("No daily returns found for portfolio {}", portfolioId);
+            return 0;
+        }
+
+        // Group by return date
+        Map<LocalDate, List<SnapshotAssetDailyReturn>> returnsByDate = allReturns.stream()
+                .collect(Collectors.groupingBy(SnapshotAssetDailyReturn::getReturnDate));
+
+        int recalculated = 0;
+
+        // Process each date in order
+        List<LocalDate> sortedDates = new ArrayList<>(returnsByDate.keySet());
+        Collections.sort(sortedDates);
+
+        for (LocalDate returnDate : sortedDates) {
+            List<SnapshotAssetDailyReturn> returns = returnsByDate.get(returnDate);
+
+            try {
+                recalculateWeightsForDate(portfolioId, returnDate, returns);
+                recalculated += returns.size();
+            } catch (Exception e) {
+                log.error("Failed to recalculate weights for portfolio {} on {}: {}",
+                        portfolioId, returnDate, e.getMessage());
+            }
+        }
+
+        return recalculated;
+    }
+
+    /**
+     * Recalculate market-cap based weights for a specific date
+     */
+    private void recalculateWeightsForDate(UUID portfolioId, LocalDate returnDate,
+                                           List<SnapshotAssetDailyReturn> returns) {
+        if (returns.isEmpty()) {
+            return;
+        }
+
+        // Get snapshot (should be same for all returns in this date)
+        UUID snapshotId = returns.get(0).getSnapshotId();
+
+        // Get snapshot to find effective date
+        PortfolioSnapshot snapshot = portfolioSnapshotRepository.findById(snapshotId)
+                .orElseThrow(() -> new IllegalStateException("Snapshot not found: " + snapshotId));
+
+        // Get initial weights from snapshot
+        List<PortfolioSnapshotAsset> snapshotAssets = portfolioSnapshotAssetRepository.findBySnapshotId(snapshotId);
+        Map<UUID, BigDecimal> initialWeightMap = snapshotAssets.stream()
+                .collect(Collectors.toMap(
+                        PortfolioSnapshotAsset::getAssetId,
+                        PortfolioSnapshotAsset::getWeight
+                ));
+
+        // Calculate current values
+        BigDecimal totalCurrentValue = BigDecimal.ZERO;
+        Map<UUID, BigDecimal> currentValueMap = new HashMap<>();
+
+        for (SnapshotAssetDailyReturn dailyReturn : returns) {
+            UUID assetId = dailyReturn.getAssetId();
+            BigDecimal initialWeight = initialWeightMap.get(assetId);
+
+            if (initialWeight == null) {
+                log.warn("No initial weight found for asset {} in snapshot {}", assetId, snapshotId);
+                continue;
+            }
+
+            // Calculate current value: initialWeight × (1 + totalReturn/100)
+            BigDecimal returnMultiplier = BigDecimal.ONE.add(
+                    dailyReturn.getAssetReturnTotal().divide(BigDecimal.valueOf(100), 8, RoundingMode.HALF_UP)
+            );
+            BigDecimal currentValue = initialWeight.multiply(returnMultiplier);
+            currentValueMap.put(assetId, currentValue);
+            totalCurrentValue = totalCurrentValue.add(currentValue);
+        }
+
+        // Update weights using reflection
+        List<SnapshotAssetDailyReturn> updatedReturns = new ArrayList<>();
+
+        for (SnapshotAssetDailyReturn dailyReturn : returns) {
+            UUID assetId = dailyReturn.getAssetId();
+            BigDecimal currentValue = currentValueMap.get(assetId);
+
+            if (currentValue == null || totalCurrentValue.compareTo(BigDecimal.ZERO) == 0) {
+                continue;
+            }
+
+            // Calculate current weight based on market value
+            BigDecimal currentWeight = currentValue
+                    .divide(totalCurrentValue, 6, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100));
+
+            // Update weightUsed using reflection
+            try {
+                java.lang.reflect.Field weightUsedField = SnapshotAssetDailyReturn.class.getDeclaredField("weightUsed");
+                weightUsedField.setAccessible(true);
+                weightUsedField.set(dailyReturn, currentWeight);
+                updatedReturns.add(dailyReturn);
+            } catch (Exception e) {
+                log.error("Failed to update weightUsed for asset {}: {}", assetId, e.getMessage());
+            }
+        }
+
+        // Save updated returns
+        if (!updatedReturns.isEmpty()) {
+            snapshotAssetDailyReturnRepository.saveAll(updatedReturns);
+        }
+    }
+}

--- a/src/main/java/com/porcana/batch/runner/RecalculateWeightUsedRunner.java
+++ b/src/main/java/com/porcana/batch/runner/RecalculateWeightUsedRunner.java
@@ -189,11 +189,9 @@ public class RecalculateWeightUsedRunner implements ApplicationRunner {
             BigDecimal initialWeight = initialWeightMap.get(assetId);
 
             if (initialWeight == null) {
-                // Use equal distribution if initial weight is missing
-                log.warn("No initial weight found for asset {} in snapshot {}. Using equal distribution (100 / {} assets).",
-                        assetId, snapshotId, snapshotAssets.size());
-                initialWeight = BigDecimal.valueOf(100.0)
-                        .divide(BigDecimal.valueOf(snapshotAssets.size()), 6, RoundingMode.HALF_UP);
+                log.warn("No initial weight found for asset {} in snapshot {} on {}. Skipping this date to prevent data loss.",
+                        assetId, snapshotId, returnDate);
+                return;  // Skip entire date to preserve existing data
             }
 
             // Calculate initial investment amount in KRW

--- a/src/main/java/com/porcana/domain/home/service/HomeService.java
+++ b/src/main/java/com/porcana/domain/home/service/HomeService.java
@@ -10,6 +10,7 @@ import com.porcana.domain.portfolio.entity.PortfolioDailyReturn;
 import com.porcana.domain.portfolio.repository.PortfolioAssetRepository;
 import com.porcana.domain.portfolio.repository.PortfolioDailyReturnRepository;
 import com.porcana.domain.portfolio.repository.PortfolioRepository;
+import com.porcana.domain.portfolio.repository.SnapshotAssetDailyReturnRepository;
 import com.porcana.domain.portfolio.service.PortfolioReturnCalculator;
 import com.porcana.domain.user.entity.User;
 import com.porcana.domain.user.repository.UserRepository;
@@ -17,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -33,6 +33,7 @@ public class HomeService {
     private final PortfolioDailyReturnRepository portfolioDailyReturnRepository;
     private final AssetRepository assetRepository;
     private final PortfolioReturnCalculator portfolioReturnCalculator;
+    private final SnapshotAssetDailyReturnRepository snapshotAssetDailyReturnRepository;
 
     public HomeResponse getHome(UUID userId) {
         User user = userRepository.findById(userId)
@@ -148,6 +149,9 @@ public class HomeService {
         // Calculate individual asset returns
         Map<UUID, Double> assetReturns = calculateAssetReturns(portfolioId, assetIds);
 
+        // Get latest market-cap based weights
+        Map<UUID, Double> latestWeights = getLatestWeights(portfolioId, assetIds);
+
         return portfolioAssets.stream()
                 .map(pa -> {
                     Asset asset = assetMap.get(pa.getAssetId());
@@ -156,19 +160,39 @@ public class HomeService {
                     }
 
                     Double returnPct = assetReturns.getOrDefault(pa.getAssetId(), 0.0);
+                    // Use latest market-cap based weight, fallback to initial weight if not available
+                    Double weightPct = latestWeights.getOrDefault(pa.getAssetId(), pa.getWeightPct().doubleValue());
 
                     return HomeResponse.PositionInfo.builder()
                             .assetId(asset.getId().toString())
                             .ticker(asset.getSymbol())
                             .name(asset.getName())
                             .imageUrl(asset.getImageUrl())
-                            .weightPct(pa.getWeightPct().doubleValue())
+                            .weightPct(weightPct)
                             .returnPct(returnPct)
                             .build();
                 })
                 .filter(Objects::nonNull)
                 .sorted((p1, p2) -> Double.compare(p2.getWeightPct(), p1.getWeightPct())) // Sort by weight descending
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Get latest market-cap based weights for assets
+     * Returns the most recent weightUsed from SnapshotAssetDailyReturn
+     */
+    private Map<UUID, Double> getLatestWeights(UUID portfolioId, Set<UUID> assetIds) {
+        Map<UUID, Double> weights = new HashMap<>();
+
+        for (UUID assetId : assetIds) {
+            snapshotAssetDailyReturnRepository
+                    .findFirstByPortfolioIdAndAssetIdOrderByReturnDateDesc(portfolioId, assetId)
+                    .ifPresent(dailyReturn ->
+                            weights.put(assetId, dailyReturn.getWeightUsed().doubleValue())
+                    );
+        }
+
+        return weights;
     }
 
     private Map<UUID, Double> calculateAssetReturns(UUID portfolioId, Set<UUID> assetIds) {

--- a/src/main/java/com/porcana/domain/home/service/HomeService.java
+++ b/src/main/java/com/porcana/domain/home/service/HomeService.java
@@ -187,8 +187,11 @@ public class HomeService {
         for (UUID assetId : assetIds) {
             snapshotAssetDailyReturnRepository
                     .findFirstByPortfolioIdAndAssetIdOrderByReturnDateDesc(portfolioId, assetId)
-                    .ifPresent(dailyReturn ->
-                            weights.put(assetId, dailyReturn.getWeightUsed().doubleValue())
+                    .ifPresent(dailyReturn -> {
+                        if (dailyReturn.getWeightUsed() != null) {
+                                weights.put(assetId, dailyReturn.getWeightUsed().doubleValue());
+                            }
+                        }
                     );
         }
 

--- a/src/main/java/com/porcana/domain/portfolio/entity/PortfolioDailyReturn.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/PortfolioDailyReturn.java
@@ -68,6 +68,13 @@ public class PortfolioDailyReturn {
     private BigDecimal returnFx;
 
     /**
+     * 포트폴리오 전체 평가금액 (원화 기준)
+     * 기준: 초기 10,000,000원 투자 가정
+     */
+    @Column(nullable = false, precision = 20, scale = 2, name = "total_value_krw")
+    private BigDecimal totalValueKrw;
+
+    /**
      * 계산 완료 시각
      */
     @CreationTimestamp
@@ -76,17 +83,20 @@ public class PortfolioDailyReturn {
 
     @Builder(access = AccessLevel.PRIVATE)
     public PortfolioDailyReturn(UUID portfolioId, UUID snapshotId, LocalDate returnDate,
-                                BigDecimal returnTotal, BigDecimal returnLocal, BigDecimal returnFx) {
+                                BigDecimal returnTotal, BigDecimal returnLocal, BigDecimal returnFx,
+                                BigDecimal totalValueKrw) {
         this.portfolioId = portfolioId;
         this.snapshotId = snapshotId;
         this.returnDate = returnDate;
         this.returnTotal = returnTotal;
         this.returnLocal = returnLocal;
         this.returnFx = returnFx;
+        this.totalValueKrw = totalValueKrw;
     }
 
     public static PortfolioDailyReturn from(UUID portfolioId, UUID snapshotId, LocalDate returnDate,
-                                            BigDecimal returnTotal, BigDecimal returnLocal, BigDecimal returnFx) {
+                                            BigDecimal returnTotal, BigDecimal returnLocal, BigDecimal returnFx,
+                                            BigDecimal totalValueKrw) {
         return PortfolioDailyReturn.builder()
                 .portfolioId(portfolioId)
                 .snapshotId(snapshotId)
@@ -94,6 +104,7 @@ public class PortfolioDailyReturn {
                 .returnTotal(returnTotal)
                 .returnLocal(returnLocal)
                 .returnFx(returnFx)
+                .totalValueKrw(totalValueKrw)
                 .build();
     }
 }

--- a/src/main/java/com/porcana/domain/portfolio/entity/SnapshotAssetDailyReturn.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/SnapshotAssetDailyReturn.java
@@ -83,6 +83,14 @@ public class SnapshotAssetDailyReturn {
     private BigDecimal contributionTotal;
 
     /**
+     * 자산 평가금액 (원화 기준)
+     * 초기 비중 × 초기 투자금 × (1 + 수익률)
+     * 예: 10% × 10,000,000원 × 1.20 = 1,200,000원
+     */
+    @Column(nullable = false, precision = 20, scale = 2, name = "value_krw")
+    private BigDecimal valueKrw;
+
+    /**
      * 계산 완료 시각
      */
     @CreationTimestamp
@@ -92,7 +100,7 @@ public class SnapshotAssetDailyReturn {
     @Builder(access = AccessLevel.PRIVATE)
     public SnapshotAssetDailyReturn(UUID portfolioId, UUID snapshotId, UUID assetId, LocalDate returnDate,
                                     BigDecimal weightUsed, BigDecimal assetReturnLocal, BigDecimal assetReturnTotal,
-                                    BigDecimal fxReturn, BigDecimal contributionTotal) {
+                                    BigDecimal fxReturn, BigDecimal contributionTotal, BigDecimal valueKrw) {
         this.portfolioId = portfolioId;
         this.snapshotId = snapshotId;
         this.assetId = assetId;
@@ -102,12 +110,13 @@ public class SnapshotAssetDailyReturn {
         this.assetReturnTotal = assetReturnTotal;
         this.fxReturn = fxReturn;
         this.contributionTotal = contributionTotal;
+        this.valueKrw = valueKrw;
     }
 
     public static SnapshotAssetDailyReturn from(UUID portfolioId, UUID snapshotId, UUID assetId, LocalDate returnDate,
                                                 BigDecimal weightUsed, BigDecimal assetReturnLocal,
                                                 BigDecimal assetReturnTotal, BigDecimal fxReturn,
-                                                BigDecimal contributionTotal) {
+                                                BigDecimal contributionTotal, BigDecimal valueKrw) {
         return SnapshotAssetDailyReturn.builder()
                 .portfolioId(portfolioId)
                 .snapshotId(snapshotId)
@@ -118,6 +127,7 @@ public class SnapshotAssetDailyReturn {
                 .assetReturnTotal(assetReturnTotal)
                 .fxReturn(fxReturn)
                 .contributionTotal(contributionTotal)
+                .valueKrw(valueKrw)
                 .build();
     }
 }

--- a/src/main/java/com/porcana/domain/portfolio/repository/SnapshotAssetDailyReturnRepository.java
+++ b/src/main/java/com/porcana/domain/portfolio/repository/SnapshotAssetDailyReturnRepository.java
@@ -54,4 +54,17 @@ public interface SnapshotAssetDailyReturnRepository extends JpaRepository<Snapsh
      * Find all asset daily returns for a specific snapshot
      */
     List<SnapshotAssetDailyReturn> findBySnapshotIdOrderByReturnDateAsc(UUID snapshotId);
+
+    /**
+     * Find the most recent asset daily return for a specific portfolio and asset
+     * (Used to get the latest market-cap based weight)
+     */
+    Optional<SnapshotAssetDailyReturn> findFirstByPortfolioIdAndAssetIdOrderByReturnDateDesc(
+            UUID portfolioId, UUID assetId);
+
+    /**
+     * Find all asset daily returns for the most recent date of a portfolio
+     */
+    List<SnapshotAssetDailyReturn> findByPortfolioIdAndReturnDateOrderByAssetIdAsc(
+            UUID portfolioId, LocalDate returnDate);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,9 @@ batch:
       base-url: https://financialmodelingprep.com
     exchangerate:
       api-key: ${KOREAEXIM_API_KEY:}
+  runner:
+    recalculate-weight-used:
+      enabled: ${RECALCULATE_WEIGHT_USED_ENABLED:false}  # Enable to recalculate existing weightUsed data
 
 management:
   endpoints:

--- a/src/main/resources/db/migration/V10__add_value_krw_columns.sql
+++ b/src/main/resources/db/migration/V10__add_value_krw_columns.sql
@@ -1,0 +1,26 @@
+-- Add value_krw columns to portfolio daily returns tables
+-- These columns track the actual KRW-based portfolio value (assuming 10M KRW initial investment)
+
+-- Add total_value_krw to portfolio_daily_returns
+ALTER TABLE portfolio_daily_returns
+ADD COLUMN total_value_krw DECIMAL(20, 2) NOT NULL DEFAULT 10000000.00;
+
+COMMENT ON COLUMN portfolio_daily_returns.total_value_krw IS '포트폴리오 전체 평가금액 (원화 기준, 초기 10,000,000원 투자 가정)';
+
+-- Add value_krw to snapshot_asset_daily_returns
+ALTER TABLE snapshot_asset_daily_returns
+ADD COLUMN value_krw DECIMAL(20, 2) NOT NULL DEFAULT 0.00;
+
+COMMENT ON COLUMN snapshot_asset_daily_returns.value_krw IS '자산 평가금액 (원화 기준)';
+
+-- Update existing data: Calculate value_krw based on weightUsed
+-- value_krw = 10,000,000 * (weightUsed / 100) * (1 + assetReturnTotal / 100)
+UPDATE snapshot_asset_daily_returns
+SET value_krw = 10000000.00 * (weight_used / 100.0) * (1.0 + asset_return_total / 100.0)
+WHERE value_krw = 0.00;
+
+-- Update existing data: Calculate total_value_krw based on return
+-- total_value_krw = 10,000,000 * (1 + returnTotal / 100)
+UPDATE portfolio_daily_returns
+SET total_value_krw = 10000000.00 * (1.0 + return_total / 100.0)
+WHERE total_value_krw = 10000000.00;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 보유 자산 가중치가 시장가치 기반으로 매일 동적으로 계산되어 표시됩니다.
  * 포트폴리오 및 자산의 KRW 가치(total/valueKrw)를 일별로 저장·추적합니다.
  * 가중치 재계산을 배치 또는 수동으로 실행하는 기능(설정으로 활성화 가능)이 추가되었습니다.
  * 홈/포지션 뷰는 최신 시장가중치 기준으로 정렬·표시됩니다.

* **문서**
  * 포트폴리오 도메인 모델, 두 단계 계산 흐름, 스냅샷·리밸런스 시나리오 및 API 사용법 문서가 대폭 확장되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->