### PR TITLE
포트폴리오 삭제 기능 추가

### DIFF
--- a/.claude/skills/api-specs/SKILL.md
+++ b/.claude/skills/api-specs/SKILL.md
@@ -360,6 +360,32 @@ Error Responses
 - 400: 포트폴리오를 찾을 수 없거나 권한이 없음
 - 401: 인증 필요
 
+### DELETE /portfolios/{portfolioId}
+**Description**: 포트폴리오를 삭제합니다. Soft delete로 처리되며, 30일 후 배치 작업에 의해 완전히 삭제됩니다.
+
+**Auth**: Required (JWT 또는 Guest Session)
+
+**소유권 검증:**
+- 사용자 소유 포트폴리오: JWT 토큰의 userId와 일치해야 함
+- 게스트 소유 포트폴리오: `X-Guest-Session-Id` 헤더와 일치해야 함
+
+Response (204 No Content)
+```
+(empty body)
+```
+
+Error Responses
+- 400: 포트폴리오를 찾을 수 없음
+- 403: 포트폴리오 삭제 권한이 없음
+- 401: 인증 필요
+
+**Notes:**
+- 삭제된 포트폴리오는 목록 조회에서 제외됨
+- 삭제된 포트폴리오는 수정 불가
+- 30일 보관 기간 후 `deletedPortfolioCleanupJob` 배치에 의해 완전 삭제
+
+---
+
 ### PUT /portfolios/{portfolioId}/weights
 **Description**: 포트폴리오 내 자산들의 비중을 일괄 수정합니다. 비중의 합계는 반드시 100%가 되어야 합니다.
 

--- a/.claude/skills/api-specs/SKILL.md
+++ b/.claude/skills/api-specs/SKILL.md
@@ -375,11 +375,12 @@ Response (204 No Content)
 ```
 
 Error Responses
-- 400: 포트폴리오를 찾을 수 없음
+- 400: 포트폴리오를 찾을 수 없음, 메인 포트폴리오 삭제 시도
 - 403: 포트폴리오 삭제 권한이 없음
 - 401: 인증 필요
 
 **Notes:**
+- **메인 포트폴리오는 삭제 불가** - 먼저 `PUT /portfolios/{portfolioId}/main`으로 다른 포트폴리오를 메인으로 설정해야 함
 - 삭제된 포트폴리오는 목록 조회에서 제외됨
 - 삭제된 포트폴리오는 수정 불가
 - 30일 보관 기간 후 `deletedPortfolioCleanupJob` 배치에 의해 완전 삭제

--- a/src/main/java/com/porcana/batch/job/DeletedPortfolioCleanupBatchJob.java
+++ b/src/main/java/com/porcana/batch/job/DeletedPortfolioCleanupBatchJob.java
@@ -104,26 +104,26 @@ public class DeletedPortfolioCleanupBatchJob {
         int snapshotAssetDailyReturnsDeleted = snapshotAssetDailyReturnRepository.deleteByPortfolioId(portfolioId);
         log.debug("Deleted {} snapshot asset daily returns for portfolio: {}", snapshotAssetDailyReturnsDeleted, portfolioId);
 
-        // 4. Delete PortfolioSnapshotAsset records (must be before PortfolioSnapshot)
+        // 4. Delete PortfolioDailyReturn records (must be before PortfolioSnapshot due to FK)
+        int dailyReturnsDeleted = portfolioDailyReturnRepository.deleteByPortfolioId(portfolioId);
+        log.debug("Deleted {} daily returns for portfolio: {}", dailyReturnsDeleted, portfolioId);
+
+        // 5. Delete PortfolioSnapshotAsset records (must be before PortfolioSnapshot)
         portfolioSnapshotRepository.findByPortfolioId(portfolioId).forEach(snapshot -> {
             int snapshotAssetsDeleted = portfolioSnapshotAssetRepository.deleteBySnapshotId(snapshot.getId());
             log.debug("Deleted {} snapshot assets for snapshot: {}", snapshotAssetsDeleted, snapshot.getId());
         });
 
-        // 5. Delete PortfolioSnapshot records
+        // 6. Delete PortfolioSnapshot records
         int snapshotsDeleted = portfolioSnapshotRepository.deleteByPortfolioId(portfolioId);
         log.debug("Deleted {} snapshots for portfolio: {}", snapshotsDeleted, portfolioId);
-
-        // 6. Delete PortfolioDailyReturn records
-        int dailyReturnsDeleted = portfolioDailyReturnRepository.deleteByPortfolioId(portfolioId);
-        log.debug("Deleted {} daily returns for portfolio: {}", dailyReturnsDeleted, portfolioId);
 
         // 7. Delete PortfolioAsset records
         int portfolioAssetsDeleted = portfolioAssetRepository.deleteByPortfolioId(portfolioId);
         log.debug("Deleted {} portfolio assets for portfolio: {}", portfolioAssetsDeleted, portfolioId);
 
-        // 8. Finally, delete Portfolio
+        // 8. Finally, delete Portfolio itself
         portfolioRepository.deleteById(portfolioId);
-        log.debug("Deleted portfolio: {}", portfolioId);
+        log.debug("Hard-deleted portfolio: {}", portfolioId);
     }
 }

--- a/src/main/java/com/porcana/batch/job/DeletedPortfolioCleanupBatchJob.java
+++ b/src/main/java/com/porcana/batch/job/DeletedPortfolioCleanupBatchJob.java
@@ -1,0 +1,129 @@
+package com.porcana.batch.job;
+
+import com.porcana.batch.listener.BatchNotificationListener;
+import com.porcana.domain.arena.repository.ArenaRoundRepository;
+import com.porcana.domain.arena.repository.ArenaSessionRepository;
+import com.porcana.domain.portfolio.entity.Portfolio;
+import com.porcana.domain.portfolio.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Cleanup batch job for deleted portfolios
+ * Hard-deletes portfolios that have been soft-deleted for more than 30 days
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class DeletedPortfolioCleanupBatchJob {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final PortfolioRepository portfolioRepository;
+    private final PortfolioAssetRepository portfolioAssetRepository;
+    private final PortfolioDailyReturnRepository portfolioDailyReturnRepository;
+    private final PortfolioSnapshotRepository portfolioSnapshotRepository;
+    private final PortfolioSnapshotAssetRepository portfolioSnapshotAssetRepository;
+    private final SnapshotAssetDailyReturnRepository snapshotAssetDailyReturnRepository;
+    private final ArenaSessionRepository arenaSessionRepository;
+    private final ArenaRoundRepository arenaRoundRepository;
+    private final BatchNotificationListener batchNotificationListener;
+
+    private static final int RETENTION_DAYS = 30;
+
+    @Bean
+    public Job deletedPortfolioCleanupJob() {
+        return new JobBuilder("deletedPortfolioCleanupJob", jobRepository)
+                .listener(batchNotificationListener)
+                .start(cleanupDeletedPortfoliosStep())
+                .build();
+    }
+
+    @Bean
+    public Step cleanupDeletedPortfoliosStep() {
+        return new StepBuilder("cleanupDeletedPortfoliosStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    log.info("Starting deleted portfolio cleanup (retention: {} days)", RETENTION_DAYS);
+
+                    LocalDateTime cutoffDate = LocalDateTime.now().minusDays(RETENTION_DAYS);
+                    log.info("Cutoff date for cleanup: {}", cutoffDate);
+
+                    List<Portfolio> portfoliosToDelete = portfolioRepository.findDeletedPortfoliosOlderThan(cutoffDate);
+                    log.info("Found {} portfolios to hard-delete", portfoliosToDelete.size());
+
+                    int deletedCount = 0;
+                    for (Portfolio portfolio : portfoliosToDelete) {
+                        try {
+                            hardDeletePortfolio(portfolio.getId());
+                            deletedCount++;
+                            log.info("Hard-deleted portfolio: {} (deleted at: {})",
+                                    portfolio.getId(), portfolio.getDeletedAt());
+                        } catch (Exception e) {
+                            log.error("Failed to hard-delete portfolio: {}", portfolio.getId(), e);
+                        }
+                    }
+
+                    log.info("Deleted portfolio cleanup completed: {} portfolios deleted", deletedCount);
+
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .build();
+    }
+
+    /**
+     * Hard-delete portfolio and all related data
+     * Deletion order is critical to avoid foreign key constraint violations
+     */
+    private void hardDeletePortfolio(UUID portfolioId) {
+        log.debug("Hard-deleting portfolio: {}", portfolioId);
+
+        // 1. Delete ArenaRound records (must be before ArenaSession)
+        arenaSessionRepository.findByPortfolioId(portfolioId).forEach(session -> {
+            int roundsDeleted = arenaRoundRepository.deleteBySessionId(session.getId());
+            log.debug("Deleted {} arena rounds for session: {}", roundsDeleted, session.getId());
+        });
+
+        // 2. Delete ArenaSession records
+        int arenaSessionsDeleted = arenaSessionRepository.deleteByPortfolioId(portfolioId);
+        log.debug("Deleted {} arena sessions for portfolio: {}", arenaSessionsDeleted, portfolioId);
+
+        // 3. Delete SnapshotAssetDailyReturn records
+        int snapshotAssetDailyReturnsDeleted = snapshotAssetDailyReturnRepository.deleteByPortfolioId(portfolioId);
+        log.debug("Deleted {} snapshot asset daily returns for portfolio: {}", snapshotAssetDailyReturnsDeleted, portfolioId);
+
+        // 4. Delete PortfolioSnapshotAsset records (must be before PortfolioSnapshot)
+        portfolioSnapshotRepository.findByPortfolioId(portfolioId).forEach(snapshot -> {
+            int snapshotAssetsDeleted = portfolioSnapshotAssetRepository.deleteBySnapshotId(snapshot.getId());
+            log.debug("Deleted {} snapshot assets for snapshot: {}", snapshotAssetsDeleted, snapshot.getId());
+        });
+
+        // 5. Delete PortfolioSnapshot records
+        int snapshotsDeleted = portfolioSnapshotRepository.deleteByPortfolioId(portfolioId);
+        log.debug("Deleted {} snapshots for portfolio: {}", snapshotsDeleted, portfolioId);
+
+        // 6. Delete PortfolioDailyReturn records
+        int dailyReturnsDeleted = portfolioDailyReturnRepository.deleteByPortfolioId(portfolioId);
+        log.debug("Deleted {} daily returns for portfolio: {}", dailyReturnsDeleted, portfolioId);
+
+        // 7. Delete PortfolioAsset records
+        int portfolioAssetsDeleted = portfolioAssetRepository.deleteByPortfolioId(portfolioId);
+        log.debug("Deleted {} portfolio assets for portfolio: {}", portfolioAssetsDeleted, portfolioId);
+
+        // 8. Finally, delete Portfolio
+        portfolioRepository.deleteById(portfolioId);
+        log.debug("Deleted portfolio: {}", portfolioId);
+    }
+}

--- a/src/main/java/com/porcana/domain/arena/entity/ArenaRound.java
+++ b/src/main/java/com/porcana/domain/arena/entity/ArenaRound.java
@@ -52,14 +52,38 @@ public class ArenaRound {
     @Column(name = "picked_at")
     private LocalDateTime pickedAt;
 
-    @Builder
-    public ArenaRound(UUID sessionId, Integer roundNumber, RoundType roundType,
+    @Builder(access = AccessLevel.PRIVATE)
+    private ArenaRound(UUID sessionId, Integer roundNumber, RoundType roundType,
                       List<UUID> presentedAssetIds, UUID selectedAssetId) {
         this.sessionId = sessionId;
         this.roundNumber = roundNumber;
         this.roundType = roundType;
         this.presentedAssetIds = presentedAssetIds != null ? presentedAssetIds : new ArrayList<>();
         this.selectedAssetId = selectedAssetId;
+    }
+
+    /**
+     * Create an arena round
+     */
+    public static ArenaRound create(UUID sessionId, Integer roundNumber, RoundType roundType,
+                                   List<UUID> presentedAssetIds, UUID selectedAssetId) {
+        if (sessionId == null) {
+            throw new IllegalArgumentException("sessionId must not be null");
+        }
+        if (roundNumber == null) {
+            throw new IllegalArgumentException("roundNumber must not be null");
+        }
+        if (roundType == null) {
+            throw new IllegalArgumentException("roundType must not be null");
+        }
+
+        return ArenaRound.builder()
+                .sessionId(sessionId)
+                .roundNumber(roundNumber)
+                .roundType(roundType)
+                .presentedAssetIds(presentedAssetIds)
+                .selectedAssetId(selectedAssetId)
+                .build();
     }
 
     public void setSelectedAssetId(UUID selectedAssetId) {

--- a/src/main/java/com/porcana/domain/arena/entity/ArenaSession.java
+++ b/src/main/java/com/porcana/domain/arena/entity/ArenaSession.java
@@ -80,8 +80,8 @@ public class ArenaSession {
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
 
-    @Builder
-    public ArenaSession(UUID portfolioId, UUID userId, UUID guestSessionId, SessionStatus status,
+    @Builder(access = AccessLevel.PRIVATE)
+    private ArenaSession(UUID portfolioId, UUID userId, UUID guestSessionId, SessionStatus status,
                         Integer currentRound, Integer totalRounds, RiskProfile riskProfile,
                         List<Sector> selectedSectors) {
         // Validate XOR: exactly one of userId or guestSessionId must be set
@@ -116,6 +116,20 @@ public class ArenaSession {
         return ArenaSession.builder()
                 .portfolioId(portfolioId)
                 .guestSessionId(guestSessionId)
+                .build();
+    }
+
+    /**
+     * Create a completed arena session for testing purposes
+     */
+    public static ArenaSession createCompleted(UUID portfolioId, UUID userId, SessionStatus status,
+                                               Integer currentRound, Integer totalRounds) {
+        return ArenaSession.builder()
+                .portfolioId(portfolioId)
+                .userId(userId)
+                .status(status)
+                .currentRound(currentRound)
+                .totalRounds(totalRounds)
                 .build();
     }
 

--- a/src/main/java/com/porcana/domain/arena/repository/ArenaRoundRepository.java
+++ b/src/main/java/com/porcana/domain/arena/repository/ArenaRoundRepository.java
@@ -29,4 +29,10 @@ public interface ArenaRoundRepository extends JpaRepository<ArenaRound, UUID> {
      * Used to get all ASSET rounds for portfolio completion
      */
     List<ArenaRound> findBySessionIdAndRoundType(UUID sessionId, RoundType roundType);
+
+    /**
+     * Delete all rounds for a session
+     * Returns the number of deleted rounds
+     */
+    int deleteBySessionId(UUID sessionId);
 }

--- a/src/main/java/com/porcana/domain/arena/repository/ArenaSessionRepository.java
+++ b/src/main/java/com/porcana/domain/arena/repository/ArenaSessionRepository.java
@@ -54,4 +54,18 @@ public interface ArenaSessionRepository extends JpaRepository<ArenaSession, UUID
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a FROM ArenaSession a WHERE a.guestSessionId = :guestSessionId")
     List<ArenaSession> findByGuestSessionIdForUpdate(@Param("guestSessionId") UUID guestSessionId);
+
+    // ===== Portfolio Cleanup Support =====
+
+    /**
+     * Find all sessions for a portfolio
+     * Used for hard-deleting portfolios
+     */
+    List<ArenaSession> findByPortfolioId(UUID portfolioId);
+
+    /**
+     * Delete all sessions for a portfolio
+     * Returns the number of deleted sessions
+     */
+    int deleteByPortfolioId(UUID portfolioId);
 }

--- a/src/main/java/com/porcana/domain/arena/service/ArenaService.java
+++ b/src/main/java/com/porcana/domain/arena/service/ArenaService.java
@@ -342,13 +342,13 @@ public class ArenaService {
             assets = recommendationService.generateRoundOptions(session, currentRound);
 
             // Save the round with presented choices
-            ArenaRound newRound = ArenaRound.builder()
-                    .sessionId(session.getId())
-                    .roundNumber(currentRound)
-                    .roundType(RoundType.ASSET)
-                    .presentedAssetIds(assets.stream().map(Asset::getId).collect(Collectors.toList()))
-                    .build();
-
+            ArenaRound newRound = ArenaRound.create(
+                    session.getId(),
+                    currentRound,
+                    RoundType.ASSET,
+                    assets.stream().map(Asset::getId).collect(Collectors.toList()),
+                    null
+            );
             roundRepository.save(newRound);
         }
 
@@ -451,11 +451,11 @@ public class ArenaService {
             java.util.Map<UUID, BigDecimal> assetWeights = new java.util.HashMap<>();
 
             for (UUID assetId : selectedAssetIds) {
-                PortfolioAsset portfolioAsset = PortfolioAsset.builder()
-                        .portfolioId(session.getPortfolioId())
-                        .assetId(assetId)
-                        .weightPct(equalWeight)
-                        .build();
+                PortfolioAsset portfolioAsset = PortfolioAsset.create(
+                        session.getPortfolioId(),
+                        assetId,
+                        equalWeight
+                );
 
                 portfolioAssetRepository.save(portfolioAsset);
                 assetWeights.put(assetId, equalWeight);

--- a/src/main/java/com/porcana/domain/arena/service/ArenaService.java
+++ b/src/main/java/com/porcana/domain/arena/service/ArenaService.java
@@ -470,9 +470,9 @@ public class ArenaService {
                     "Initial portfolio creation via Arena"
             );
 
-            // Auto-start the portfolio
-            Portfolio portfolio = portfolioRepository.findById(session.getPortfolioId())
-                    .orElseThrow(() -> new IllegalArgumentException("Portfolio not found"));
+            // Auto-start the portfolio (must not be deleted)
+            Portfolio portfolio = portfolioRepository.findByIdAndDeletedAtIsNull(session.getPortfolioId())
+                    .orElseThrow(() -> new IllegalStateException("Portfolio not found or has been deleted"));
             portfolio.start();
             portfolioRepository.save(portfolio);
 

--- a/src/main/java/com/porcana/domain/home/service/HomeService.java
+++ b/src/main/java/com/porcana/domain/home/service/HomeService.java
@@ -80,7 +80,7 @@ public class HomeService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
-        Portfolio portfolio = portfolioRepository.findByIdAndUserId(portfolioId, userId)
+        Portfolio portfolio = portfolioRepository.findByIdAndUserIdAndDeletedAtIsNull(portfolioId, userId)
                 .orElseThrow(() -> new IllegalArgumentException("Portfolio not found or access denied"));
 
         user.setMainPortfolioId(portfolio.getId());

--- a/src/main/java/com/porcana/domain/portfolio/PortfolioController.java
+++ b/src/main/java/com/porcana/domain/portfolio/PortfolioController.java
@@ -156,6 +156,25 @@ public class PortfolioController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "포트폴리오 삭제",
+            description = "포트폴리오를 삭제합니다 (soft delete). 삭제된 포트폴리오는 30일 후 자동으로 완전 삭제됩니다. 비회원도 삭제 가능합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "삭제 성공"),
+                    @ApiResponse(responseCode = "400", description = "포트폴리오를 찾을 수 없거나 권한이 없음", content = @Content)
+            }
+    )
+    @DeleteMapping("/{portfolioId}")
+    public ResponseEntity<Void> deletePortfolio(
+            @Parameter(description = "포트폴리오 ID", required = true) @PathVariable UUID portfolioId,
+            HttpServletRequest request) {
+        UUID userId = extractUserId();
+        UUID guestSessionId = guestSessionExtractor.extractGuestSessionId(request);
+
+        portfolioService.deletePortfolio(portfolioId, userId, guestSessionId);
+        return ResponseEntity.noContent().build();
+    }
+
     /**
      * Extract user ID from Security Context
      * Returns null if not authenticated

--- a/src/main/java/com/porcana/domain/portfolio/entity/Portfolio.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/Portfolio.java
@@ -57,6 +57,9 @@ public class Portfolio {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Builder
     public Portfolio(UUID userId, UUID guestSessionId, String name, PortfolioStatus status, LocalDate startedAt) {
         // Validate XOR: exactly one of userId or guestSessionId must be set
@@ -148,5 +151,22 @@ public class Portfolio {
             throw new IllegalArgumentException("name must be <= 100 characters");
         }
         this.name = name;
+    }
+
+    /**
+     * Soft delete the portfolio
+     */
+    public void delete() {
+        if (this.deletedAt != null) {
+            throw new IllegalStateException("Portfolio is already deleted");
+        }
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    /**
+     * Check if portfolio is deleted
+     */
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/src/main/java/com/porcana/domain/portfolio/entity/PortfolioAsset.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/PortfolioAsset.java
@@ -38,11 +38,32 @@ public class PortfolioAsset {
     @Column(name = "added_at", nullable = false, updatable = false)
     private LocalDateTime addedAt;
 
-    @Builder
-    public PortfolioAsset(UUID portfolioId, UUID assetId, BigDecimal weightPct) {
+    @Builder(access = AccessLevel.PRIVATE)
+    private PortfolioAsset(UUID portfolioId, UUID assetId, BigDecimal weightPct) {
         this.portfolioId = portfolioId;
         this.assetId = assetId;
         this.weightPct = weightPct;
+    }
+
+    /**
+     * Create a portfolio asset
+     */
+    public static PortfolioAsset create(UUID portfolioId, UUID assetId, BigDecimal weightPct) {
+        if (portfolioId == null) {
+            throw new IllegalArgumentException("portfolioId must not be null");
+        }
+        if (assetId == null) {
+            throw new IllegalArgumentException("assetId must not be null");
+        }
+        if (weightPct == null || weightPct.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("weightPct must be positive");
+        }
+
+        return PortfolioAsset.builder()
+                .portfolioId(portfolioId)
+                .assetId(assetId)
+                .weightPct(weightPct)
+                .build();
     }
 
     public void setWeightPct(BigDecimal weightPct) {

--- a/src/main/java/com/porcana/domain/portfolio/entity/PortfolioSnapshot.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/PortfolioSnapshot.java
@@ -49,10 +49,28 @@ public class PortfolioSnapshot {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Builder
-    public PortfolioSnapshot(UUID portfolioId, LocalDate effectiveDate, String note) {
+    @Builder(access = AccessLevel.PRIVATE)
+    private PortfolioSnapshot(UUID portfolioId, LocalDate effectiveDate, String note) {
         this.portfolioId = portfolioId;
         this.effectiveDate = effectiveDate;
         this.note = note;
+    }
+
+    /**
+     * Create a portfolio snapshot
+     */
+    public static PortfolioSnapshot create(UUID portfolioId, LocalDate effectiveDate, String note) {
+        if (portfolioId == null) {
+            throw new IllegalArgumentException("portfolioId must not be null");
+        }
+        if (effectiveDate == null) {
+            throw new IllegalArgumentException("effectiveDate must not be null");
+        }
+
+        return PortfolioSnapshot.builder()
+                .portfolioId(portfolioId)
+                .effectiveDate(effectiveDate)
+                .note(note)
+                .build();
     }
 }

--- a/src/main/java/com/porcana/domain/portfolio/entity/PortfolioSnapshotAsset.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/PortfolioSnapshotAsset.java
@@ -40,10 +40,31 @@ public class PortfolioSnapshotAsset {
     @Column(nullable = false, precision = 5, scale = 2)
     private BigDecimal weight;
 
-    @Builder
-    public PortfolioSnapshotAsset(UUID snapshotId, UUID assetId, BigDecimal weight) {
+    @Builder(access = AccessLevel.PRIVATE)
+    private PortfolioSnapshotAsset(UUID snapshotId, UUID assetId, BigDecimal weight) {
         this.snapshotId = snapshotId;
         this.assetId = assetId;
         this.weight = weight;
+    }
+
+    /**
+     * Create a portfolio snapshot asset
+     */
+    public static PortfolioSnapshotAsset create(UUID snapshotId, UUID assetId, BigDecimal weight) {
+        if (snapshotId == null) {
+            throw new IllegalArgumentException("snapshotId must not be null");
+        }
+        if (assetId == null) {
+            throw new IllegalArgumentException("assetId must not be null");
+        }
+        if (weight == null || weight.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("weight must be positive");
+        }
+
+        return PortfolioSnapshotAsset.builder()
+                .snapshotId(snapshotId)
+                .assetId(assetId)
+                .weight(weight)
+                .build();
     }
 }

--- a/src/main/java/com/porcana/domain/portfolio/repository/PortfolioAssetRepository.java
+++ b/src/main/java/com/porcana/domain/portfolio/repository/PortfolioAssetRepository.java
@@ -23,6 +23,7 @@ public interface PortfolioAssetRepository extends JpaRepository<PortfolioAsset, 
 
     /**
      * Delete all assets in a portfolio
+     * Returns the number of deleted assets
      */
-    void deleteByPortfolioId(UUID portfolioId);
+    int deleteByPortfolioId(UUID portfolioId);
 }

--- a/src/main/java/com/porcana/domain/portfolio/repository/PortfolioDailyReturnRepository.java
+++ b/src/main/java/com/porcana/domain/portfolio/repository/PortfolioDailyReturnRepository.java
@@ -47,4 +47,10 @@ public interface PortfolioDailyReturnRepository extends JpaRepository<PortfolioD
      * Find all daily returns for a specific snapshot
      */
     List<PortfolioDailyReturn> findBySnapshotIdOrderByReturnDateAsc(UUID snapshotId);
+
+    /**
+     * Delete all daily returns for a portfolio
+     * Returns the number of deleted records
+     */
+    int deleteByPortfolioId(UUID portfolioId);
 }

--- a/src/main/java/com/porcana/domain/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/com/porcana/domain/portfolio/repository/PortfolioRepository.java
@@ -77,6 +77,11 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, UUID> {
     // ===== Soft Delete Support =====
 
     /**
+     * Find portfolio by ID (excluding deleted)
+     */
+    Optional<Portfolio> findByIdAndDeletedAtIsNull(UUID id);
+
+    /**
      * Find deleted portfolios older than the specified date (for hard delete batch job)
      */
     @Query("SELECT p FROM Portfolio p WHERE p.deletedAt IS NOT NULL AND p.deletedAt < :cutoffDate")

--- a/src/main/java/com/porcana/domain/portfolio/repository/PortfolioSnapshotAssetRepository.java
+++ b/src/main/java/com/porcana/domain/portfolio/repository/PortfolioSnapshotAssetRepository.java
@@ -23,8 +23,9 @@ public interface PortfolioSnapshotAssetRepository extends JpaRepository<Portfoli
 
     /**
      * Delete all assets in a snapshot
+     * Returns the number of deleted assets
      */
-    void deleteBySnapshotId(UUID snapshotId);
+    int deleteBySnapshotId(UUID snapshotId);
 
     /**
      * Check if asset exists in snapshot

--- a/src/main/java/com/porcana/domain/portfolio/repository/PortfolioSnapshotRepository.java
+++ b/src/main/java/com/porcana/domain/portfolio/repository/PortfolioSnapshotRepository.java
@@ -37,4 +37,16 @@ public interface PortfolioSnapshotRepository extends JpaRepository<PortfolioSnap
      * Check if snapshot exists for portfolio and effective date
      */
     boolean existsByPortfolioIdAndEffectiveDate(UUID portfolioId, LocalDate effectiveDate);
+
+    /**
+     * Find all snapshots for a portfolio
+     * Used for hard-deleting portfolios
+     */
+    List<PortfolioSnapshot> findByPortfolioId(UUID portfolioId);
+
+    /**
+     * Delete all snapshots for a portfolio
+     * Returns the number of deleted snapshots
+     */
+    int deleteByPortfolioId(UUID portfolioId);
 }

--- a/src/main/java/com/porcana/domain/portfolio/repository/SnapshotAssetDailyReturnRepository.java
+++ b/src/main/java/com/porcana/domain/portfolio/repository/SnapshotAssetDailyReturnRepository.java
@@ -70,4 +70,10 @@ public interface SnapshotAssetDailyReturnRepository extends JpaRepository<Snapsh
      */
     List<SnapshotAssetDailyReturn> findByPortfolioIdAndReturnDateOrderByAssetIdAsc(
             UUID portfolioId, LocalDate returnDate);
+
+    /**
+     * Delete all asset daily returns for a portfolio
+     * Returns the number of deleted records
+     */
+    int deleteByPortfolioId(UUID portfolioId);
 }

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -48,11 +48,11 @@ public class PortfolioService {
             // Authenticated user
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new IllegalArgumentException("User not found"));
-            portfolios = portfolioRepository.findByUserIdOrderByCreatedAtDesc(userId);
+            portfolios = portfolioRepository.findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId);
             mainPortfolioId = user.getMainPortfolioId();
         } else if (guestSessionId != null) {
             // Guest session
-            portfolios = portfolioRepository.findByGuestSessionIdOrderByCreatedAtDesc(guestSessionId);
+            portfolios = portfolioRepository.findByGuestSessionIdAndDeletedAtIsNullOrderByCreatedAtDesc(guestSessionId);
         } else {
             throw new IllegalArgumentException("Either userId or guestSessionId must be provided");
         }
@@ -80,8 +80,8 @@ public class PortfolioService {
             // Authenticated user
             portfolio = Portfolio.createForUser(userId, command.getName());
         } else if (guestSessionId != null) {
-            // Guest session - check limit
-            long guestPortfolioCount = portfolioRepository.countByGuestSessionId(guestSessionId);
+            // Guest session - check limit (excluding deleted portfolios)
+            long guestPortfolioCount = portfolioRepository.countByGuestSessionIdAndDeletedAtIsNull(guestSessionId);
             if (guestPortfolioCount >= MAX_GUEST_PORTFOLIOS) {
                 throw new IllegalStateException(
                     String.format("Guest users can create up to %d portfolios. Please sign up to create more.", MAX_GUEST_PORTFOLIOS)
@@ -520,7 +520,7 @@ public class PortfolioService {
 
     @Transactional
     public UpdatePortfolioNameResponse updatePortfolioName(UpdatePortfolioNameCommand command) {
-        Portfolio portfolio = portfolioRepository.findByIdAndUserId(command.getPortfolioId(), command.getUserId())
+        Portfolio portfolio = portfolioRepository.findByIdAndUserIdAndDeletedAtIsNull(command.getPortfolioId(), command.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("Portfolio not found or access denied"));
 
         portfolio.updateName(command.getName());
@@ -528,9 +528,19 @@ public class PortfolioService {
         return UpdatePortfolioNameResponse.from(saved);
     }
 
+    /**
+     * Delete portfolio (soft delete)
+     */
+    @Transactional
+    public void deletePortfolio(UUID portfolioId, UUID userId, UUID guestSessionId) {
+        Portfolio portfolio = findPortfolioWithOwnership(portfolioId, userId, guestSessionId);
+        portfolio.delete();
+        portfolioRepository.save(portfolio);
+    }
+
     @Transactional
     public UpdateAssetWeightsResponse updateAssetWeights(UpdateAssetWeightsCommand command) {
-        Portfolio portfolio = portfolioRepository.findByIdAndUserId(command.getPortfolioId(), command.getUserId())
+        Portfolio portfolio = portfolioRepository.findByIdAndUserIdAndDeletedAtIsNull(command.getPortfolioId(), command.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("Portfolio not found or access denied"));
 
         // 비중 합계 검증 (100%가 되어야 함)
@@ -594,7 +604,7 @@ public class PortfolioService {
     }
 
     /**
-     * Find portfolio with ownership validation (supports both user and guest)
+     * Find portfolio with ownership validation (supports both user and guest, excludes deleted)
      * @param portfolioId Portfolio ID
      * @param userId User ID (nullable)
      * @param guestSessionId Guest session ID (nullable)
@@ -604,11 +614,11 @@ public class PortfolioService {
     private Portfolio findPortfolioWithOwnership(UUID portfolioId, UUID userId, UUID guestSessionId) {
         if (userId != null) {
             // Authenticated user
-            return portfolioRepository.findByIdAndUserId(portfolioId, userId)
+            return portfolioRepository.findByIdAndUserIdAndDeletedAtIsNull(portfolioId, userId)
                     .orElseThrow(() -> new IllegalArgumentException("Portfolio not found or access denied"));
         } else if (guestSessionId != null) {
             // Guest session
-            return portfolioRepository.findByIdAndGuestSessionId(portfolioId, guestSessionId)
+            return portfolioRepository.findByIdAndGuestSessionIdAndDeletedAtIsNull(portfolioId, guestSessionId)
                     .orElseThrow(() -> new IllegalArgumentException("Portfolio not found or access denied"));
         } else {
             throw new IllegalArgumentException("Either userId or guestSessionId must be provided");

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -530,10 +530,21 @@ public class PortfolioService {
 
     /**
      * Delete portfolio (soft delete)
+     * Main portfolio cannot be deleted - must change main portfolio first
      */
     @Transactional
     public void deletePortfolio(UUID portfolioId, UUID userId, UUID guestSessionId) {
         Portfolio portfolio = findPortfolioWithOwnership(portfolioId, userId, guestSessionId);
+
+        // 메인 포트폴리오는 삭제 불가 - 먼저 메인을 변경해야 함
+        if (userId != null) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("User not found"));
+            if (portfolioId.equals(user.getMainPortfolioId())) {
+                throw new IllegalStateException("Cannot delete main portfolio. Please change main portfolio first.");
+            }
+        }
+
         portfolio.delete();
         portfolioRepository.save(portfolio);
     }

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioSnapshotService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioSnapshotService.java
@@ -67,21 +67,16 @@ public class PortfolioSnapshotService {
         }
 
         // 스냅샷 생성
-        PortfolioSnapshot snapshot = PortfolioSnapshot.builder()
-                .portfolioId(portfolioId)
-                .effectiveDate(effectiveDate)
-                .note(note)
-                .build();
-
+        PortfolioSnapshot snapshot = PortfolioSnapshot.create(portfolioId, effectiveDate, note);
         PortfolioSnapshot savedSnapshot = snapshotRepository.save(snapshot);
 
         // 스냅샷 자산 구성 저장
         for (PortfolioAsset asset : currentAssets) {
-            PortfolioSnapshotAsset snapshotAsset = PortfolioSnapshotAsset.builder()
-                    .snapshotId(savedSnapshot.getId())
-                    .assetId(asset.getAssetId())
-                    .weight(asset.getWeightPct())
-                    .build();
+            PortfolioSnapshotAsset snapshotAsset = PortfolioSnapshotAsset.create(
+                    savedSnapshot.getId(),
+                    asset.getAssetId(),
+                    asset.getWeightPct()
+            );
 
             snapshotAssetRepository.save(snapshotAsset);
         }
@@ -144,12 +139,7 @@ public class PortfolioSnapshotService {
             }
         } else {
             // 새 스냅샷 생성
-            PortfolioSnapshot snapshot = PortfolioSnapshot.builder()
-                    .portfolioId(portfolioId)
-                    .effectiveDate(effectiveDate)
-                    .note(note)
-                    .build();
-
+            PortfolioSnapshot snapshot = PortfolioSnapshot.create(portfolioId, effectiveDate, note);
             savedSnapshot = snapshotRepository.save(snapshot);
             log.info("Created new snapshot {} for portfolio {} on {}",
                     savedSnapshot.getId(), portfolioId, effectiveDate);
@@ -157,12 +147,11 @@ public class PortfolioSnapshotService {
 
         // 스냅샷 자산 구성 저장 (새 비중으로)
         for (Map.Entry<UUID, BigDecimal> entry : assetWeights.entrySet()) {
-            PortfolioSnapshotAsset snapshotAsset = PortfolioSnapshotAsset.builder()
-                    .snapshotId(savedSnapshot.getId())
-                    .assetId(entry.getKey())
-                    .weight(entry.getValue())
-                    .build();
-
+            PortfolioSnapshotAsset snapshotAsset = PortfolioSnapshotAsset.create(
+                    savedSnapshot.getId(),
+                    entry.getKey(),
+                    entry.getValue()
+            );
             snapshotAssetRepository.save(snapshotAsset);
         }
 

--- a/src/main/resources/db/migration/V20__add_deleted_at_to_portfolios.sql
+++ b/src/main/resources/db/migration/V20__add_deleted_at_to_portfolios.sql
@@ -1,0 +1,9 @@
+-- Add deleted_at column to portfolios table for soft delete functionality
+
+ALTER TABLE portfolios ADD COLUMN deleted_at TIMESTAMP NULL;
+
+-- Add index for deleted_at to optimize queries filtering out deleted portfolios
+CREATE INDEX idx_portfolios_deleted_at ON portfolios(deleted_at);
+
+-- Add comment to the column
+COMMENT ON COLUMN portfolios.deleted_at IS 'Soft delete timestamp. NULL means not deleted. Non-NULL means deleted and will be hard-deleted after 30 days.';

--- a/src/test/java/com/porcana/batch/job/DeletedPortfolioCleanupBatchJobTest.java
+++ b/src/test/java/com/porcana/batch/job/DeletedPortfolioCleanupBatchJobTest.java
@@ -1,0 +1,153 @@
+package com.porcana.batch.job;
+
+import com.porcana.domain.arena.repository.ArenaRoundRepository;
+import com.porcana.domain.arena.repository.ArenaSessionRepository;
+import com.porcana.domain.portfolio.repository.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers
+@Sql(scripts = "/sql/batch-cleanup-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class DeletedPortfolioCleanupBatchJobTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("porcana_test")
+            .withUsername("test")
+            .withPassword("test")
+            .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    @Autowired
+    private Job deletedPortfolioCleanupJob;
+
+    @Autowired
+    private PortfolioRepository portfolioRepository;
+
+    @Autowired
+    private PortfolioAssetRepository portfolioAssetRepository;
+
+    @Autowired
+    private PortfolioDailyReturnRepository portfolioDailyReturnRepository;
+
+    @Autowired
+    private PortfolioSnapshotRepository portfolioSnapshotRepository;
+
+    @Autowired
+    private PortfolioSnapshotAssetRepository portfolioSnapshotAssetRepository;
+
+    @Autowired
+    private SnapshotAssetDailyReturnRepository snapshotAssetDailyReturnRepository;
+
+    @Autowired
+    private ArenaSessionRepository arenaSessionRepository;
+
+    @Autowired
+    private ArenaRoundRepository arenaRoundRepository;
+
+    // Test IDs from SQL file
+    private static final UUID OLD_DELETED_PORTFOLIO_ID = UUID.fromString("eeeeeeee-0000-0000-0000-000000000001");
+    private static final UUID RECENT_DELETED_PORTFOLIO_ID = UUID.fromString("77777777-0000-0000-0000-000000000001");
+    private static final UUID ACTIVE_PORTFOLIO_ID = UUID.fromString("88888888-0000-0000-0000-000000000001");
+    private static final UUID OLD_SNAPSHOT_ID = UUID.fromString("11111111-0000-0000-0000-000000000001");
+    private static final UUID OLD_ARENA_SESSION_ID = UUID.fromString("55555555-0000-0000-0000-000000000001");
+
+    @Test
+    @DisplayName("30일 이상 경과한 삭제 포트폴리오 하드 삭제 성공")
+    void deleteOldPortfolios_success() throws Exception {
+        // Given - data loaded from SQL file
+
+        // When
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+        JobExecution jobExecution = jobLauncher.run(deletedPortfolioCleanupJob, jobParameters);
+
+        // Then
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+
+        // Old deleted portfolio and all related data should be hard-deleted
+        assertThat(portfolioRepository.findById(OLD_DELETED_PORTFOLIO_ID)).isEmpty();
+        assertThat(portfolioAssetRepository.findByPortfolioId(OLD_DELETED_PORTFOLIO_ID)).isEmpty();
+        assertThat(portfolioSnapshotRepository.findById(OLD_SNAPSHOT_ID)).isEmpty();
+        assertThat(portfolioSnapshotAssetRepository.findBySnapshotId(OLD_SNAPSHOT_ID)).isEmpty();
+        assertThat(portfolioDailyReturnRepository.findByPortfolioIdOrderByReturnDateAsc(OLD_DELETED_PORTFOLIO_ID)).isEmpty();
+        assertThat(snapshotAssetDailyReturnRepository.findByPortfolioIdOrderByReturnDateAsc(OLD_DELETED_PORTFOLIO_ID)).isEmpty();
+        assertThat(arenaSessionRepository.findById(OLD_ARENA_SESSION_ID)).isEmpty();
+        assertThat(arenaRoundRepository.findBySessionIdOrderByRoundNumberAsc(OLD_ARENA_SESSION_ID)).isEmpty();
+
+        // Recent deleted portfolio should still exist (soft-deleted)
+        assertThat(portfolioRepository.findById(RECENT_DELETED_PORTFOLIO_ID)).isPresent();
+        assertThat(portfolioRepository.findById(RECENT_DELETED_PORTFOLIO_ID).get().isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("삭제되지 않은 포트폴리오는 영향 없음")
+    void doNotDeleteActivePortfolios() throws Exception {
+        // Given - active portfolio loaded from SQL file
+
+        // When
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+        JobExecution jobExecution = jobLauncher.run(deletedPortfolioCleanupJob, jobParameters);
+
+        // Then
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+
+        // Active portfolio should still exist
+        assertThat(portfolioRepository.findById(ACTIVE_PORTFOLIO_ID)).isPresent();
+        assertThat(portfolioRepository.findById(ACTIVE_PORTFOLIO_ID).get().isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("배치 실행 - 모든 포트폴리오가 정상 처리됨")
+    void batchCompletesSuccessfully() throws Exception {
+        // Given - portfolios from SQL file (old deleted, recent deleted, active)
+
+        // When
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+        JobExecution jobExecution = jobLauncher.run(deletedPortfolioCleanupJob, jobParameters);
+
+        // Then
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+
+        // Verify expected state after batch
+        assertThat(portfolioRepository.findById(OLD_DELETED_PORTFOLIO_ID)).isEmpty(); // Hard deleted
+        assertThat(portfolioRepository.findById(RECENT_DELETED_PORTFOLIO_ID)).isPresent(); // Kept (soft deleted)
+        assertThat(portfolioRepository.findById(ACTIVE_PORTFOLIO_ID)).isPresent(); // Kept (active)
+    }
+}

--- a/src/test/java/com/porcana/domain/portfolio/PortfolioControllerTest.java
+++ b/src/test/java/com/porcana/domain/portfolio/PortfolioControllerTest.java
@@ -500,6 +500,28 @@ class PortfolioControllerTest extends BaseIntegrationTest {
     }
 
     @Test
+    @DisplayName("메인 포트폴리오 삭제 실패 - 메인 변경 필요")
+    void deletePortfolio_fail_mainPortfolio() {
+        String accessToken = createAccessToken();
+
+        // 메인 포트폴리오로 설정
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .put("/portfolios/{portfolioId}/main", TEST_PORTFOLIO_ID)
+        .then()
+                .statusCode(200);
+
+        // 메인 포트폴리오 삭제 시도 - 실패해야 함
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .delete("/portfolios/{portfolioId}", TEST_PORTFOLIO_ID)
+        .then()
+                .statusCode(400);
+    }
+
+    @Test
     @DisplayName("포트폴리오 삭제 후 목록에서 제외됨")
     void deletePortfolio_notInList() {
         String accessToken = createAccessToken();

--- a/src/test/java/com/porcana/domain/portfolio/PortfolioControllerTest.java
+++ b/src/test/java/com/porcana/domain/portfolio/PortfolioControllerTest.java
@@ -420,4 +420,159 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 // 재조정된 비중 70/30이 홈 화면에도 반영되어야 함
                 .body("positions.weightPct", hasItems(70.0f, 30.0f));
     }
+
+    @Test
+    @DisplayName("포트폴리오 삭제 성공 - 회원")
+    void deletePortfolio_success() {
+        String accessToken = createAccessToken();
+
+        // 삭제 전 포트폴리오 조회 성공
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .get("/portfolios/{portfolioId}", TEST_PORTFOLIO_ID)
+        .then()
+                .statusCode(200);
+
+        // 포트폴리오 삭제
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .delete("/portfolios/{portfolioId}", TEST_PORTFOLIO_ID)
+        .then()
+                .log().all()
+                .statusCode(204);
+
+        // 삭제 후 포트폴리오 조회 실패 (404 또는 400)
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .get("/portfolios/{portfolioId}", TEST_PORTFOLIO_ID)
+        .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("포트폴리오 삭제 성공 - 게스트")
+    @Sql(scripts = "/sql/portfolio-guest-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    void deletePortfolio_success_guest() {
+        UUID guestSessionId = UUID.fromString("aaa00000-0000-0000-0000-000000000001");
+        UUID guestPortfolioId = UUID.fromString("bbb00000-0000-0000-0000-000000000001");
+
+        // 삭제 전 포트폴리오 조회 성공
+        given()
+                .header("X-Guest-Session-Id", guestSessionId.toString())
+        .when()
+                .get("/portfolios/{portfolioId}", guestPortfolioId)
+        .then()
+                .statusCode(200);
+
+        // 포트폴리오 삭제
+        given()
+                .header("X-Guest-Session-Id", guestSessionId.toString())
+        .when()
+                .delete("/portfolios/{portfolioId}", guestPortfolioId)
+        .then()
+                .log().all()
+                .statusCode(204);
+
+        // 삭제 후 포트폴리오 조회 실패
+        given()
+                .header("X-Guest-Session-Id", guestSessionId.toString())
+        .when()
+                .get("/portfolios/{portfolioId}", guestPortfolioId)
+        .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("포트폴리오 삭제 실패 - 권한 없음")
+    void deletePortfolio_fail_noPermission() {
+        String accessToken = createAccessToken();
+        UUID otherPortfolioId = UUID.randomUUID();
+
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .delete("/portfolios/{portfolioId}", otherPortfolioId)
+        .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @DisplayName("포트폴리오 삭제 후 목록에서 제외됨")
+    void deletePortfolio_notInList() {
+        String accessToken = createAccessToken();
+
+        // 삭제 전 목록 조회 - 포트폴리오가 있음
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .get("/portfolios")
+        .then()
+                .statusCode(200)
+                .body("$", hasSize(greaterThanOrEqualTo(1)))
+                .body("find { it.portfolioId == '" + TEST_PORTFOLIO_ID + "' }", notNullValue());
+
+        // 포트폴리오 삭제
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .delete("/portfolios/{portfolioId}", TEST_PORTFOLIO_ID)
+        .then()
+                .statusCode(204);
+
+        // 삭제 후 목록 조회 - 포트폴리오가 없음
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .get("/portfolios")
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("find { it.portfolioId == '" + TEST_PORTFOLIO_ID + "' }", nullValue());
+    }
+
+    @Test
+    @DisplayName("삭제된 포트폴리오 수정 불가")
+    void deletePortfolio_cannotUpdate() {
+        String accessToken = createAccessToken();
+
+        // 포트폴리오 삭제
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .delete("/portfolios/{portfolioId}", TEST_PORTFOLIO_ID)
+        .then()
+                .statusCode(204);
+
+        // 삭제 후 이름 수정 시도
+        UpdatePortfolioNameRequest request = new UpdatePortfolioNameRequest("새 이름");
+
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body(request)
+        .when()
+                .patch("/portfolios/{portfolioId}/name", TEST_PORTFOLIO_ID)
+        .then()
+                .statusCode(400);
+
+        // 삭제 후 비중 수정 시도
+        UpdateAssetWeightsRequest weightRequest = new UpdateAssetWeightsRequest(
+                List.of(
+                        new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
+                        new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
+                )
+        );
+
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body(weightRequest)
+        .when()
+                .put("/portfolios/{portfolioId}/weights", TEST_PORTFOLIO_ID)
+        .then()
+                .statusCode(400);
+    }
 }

--- a/src/test/resources/sql/batch-cleanup-test-data.sql
+++ b/src/test/resources/sql/batch-cleanup-test-data.sql
@@ -1,0 +1,101 @@
+-- Test data for DeletedPortfolioCleanupBatchJobTest
+
+-- Clean up existing test data
+DELETE FROM arena_round_choices WHERE round_id IN (
+    SELECT id FROM arena_rounds WHERE session_id IN (
+        SELECT id FROM arena_sessions WHERE user_id = 'bbbbbbbb-0000-0000-0000-000000000001'
+    )
+);
+DELETE FROM arena_rounds WHERE session_id IN (
+    SELECT id FROM arena_sessions WHERE user_id = 'bbbbbbbb-0000-0000-0000-000000000001'
+);
+DELETE FROM arena_sessions WHERE user_id = 'bbbbbbbb-0000-0000-0000-000000000001';
+DELETE FROM snapshot_asset_daily_returns WHERE portfolio_id IN (
+    SELECT id FROM portfolios WHERE user_id = 'bbbbbbbb-0000-0000-0000-000000000001'
+);
+DELETE FROM portfolio_daily_returns WHERE portfolio_id IN (
+    SELECT id FROM portfolios WHERE user_id = 'bbbbbbbb-0000-0000-0000-000000000001'
+);
+DELETE FROM portfolio_snapshot_assets WHERE snapshot_id IN (
+    SELECT id FROM portfolio_snapshots WHERE portfolio_id IN (
+        SELECT id FROM portfolios WHERE user_id = 'bbbbbbbb-0000-0000-0000-000000000001'
+    )
+);
+DELETE FROM portfolio_snapshots WHERE portfolio_id IN (
+    SELECT id FROM portfolios WHERE user_id = 'bbbbbbbb-0000-0000-0000-000000000001'
+);
+DELETE FROM portfolio_assets WHERE portfolio_id IN (
+    SELECT id FROM portfolios WHERE user_id = 'bbbbbbbb-0000-0000-0000-000000000001'
+);
+DELETE FROM portfolios WHERE user_id = 'bbbbbbbb-0000-0000-0000-000000000001';
+DELETE FROM users WHERE id = 'bbbbbbbb-0000-0000-0000-000000000001';
+DELETE FROM assets WHERE symbol IN ('BATCH_TEST_1', 'BATCH_TEST_2');
+
+-- Insert test user
+INSERT INTO users (id, email, password, nickname, provider, created_at, updated_at)
+VALUES ('bbbbbbbb-0000-0000-0000-000000000001', 'batch-test@example.com', 'password123', '배치테스터', 'EMAIL', NOW(), NOW());
+
+-- Insert test assets
+INSERT INTO assets (id, symbol, name, market, type, sector, current_risk_level, active, created_at, updated_at, as_of)
+VALUES
+    ('cccccccc-0000-0000-0000-000000000001', 'BATCH_TEST_1', '배치테스트자산1', 'KR', 'STOCK', 'INFORMATION_TECHNOLOGY', 3, true, NOW(), NOW(), NOW()),
+    ('dddddddd-0000-0000-0000-000000000001', 'BATCH_TEST_2', '배치테스트자산2', 'US', 'STOCK', 'HEALTH_CARE', 4, true, NOW(), NOW(), NOW());
+
+-- Insert old deleted portfolio (31 days ago) - should be hard deleted
+INSERT INTO portfolios (id, user_id, name, status, started_at, created_at, updated_at, deleted_at)
+VALUES ('eeeeeeee-0000-0000-0000-000000000001', 'bbbbbbbb-0000-0000-0000-000000000001', 'Old Deleted Portfolio', 'ACTIVE',
+        NOW() - INTERVAL '100 days', NOW() - INTERVAL '100 days', NOW() - INTERVAL '31 days', NOW() - INTERVAL '31 days');
+
+-- Insert portfolio assets for old deleted portfolio
+INSERT INTO portfolio_assets (id, portfolio_id, asset_id, weight_pct, added_at)
+VALUES ('ffffffff-0000-0000-0000-000000000001', 'eeeeeeee-0000-0000-0000-000000000001', 'cccccccc-0000-0000-0000-000000000001', 50.00, NOW() - INTERVAL '100 days');
+
+-- Insert portfolio snapshot for old deleted portfolio
+INSERT INTO portfolio_snapshots (id, portfolio_id, effective_date, note, created_at)
+VALUES ('11111111-0000-0000-0000-000000000001', 'eeeeeeee-0000-0000-0000-000000000001', NOW() - INTERVAL '50 days', 'Initial', NOW() - INTERVAL '50 days');
+
+-- Insert portfolio snapshot asset
+INSERT INTO portfolio_snapshot_assets (id, snapshot_id, asset_id, weight)
+VALUES ('22222222-0000-0000-0000-000000000001', '11111111-0000-0000-0000-000000000001', 'cccccccc-0000-0000-0000-000000000001', 50.00);
+
+-- Insert portfolio daily return
+INSERT INTO portfolio_daily_returns (id, portfolio_id, snapshot_id, return_date, return_total, return_local, return_fx, total_value_krw, calculated_at)
+VALUES ('33333333-0000-0000-0000-000000000001', 'eeeeeeee-0000-0000-0000-000000000001', '11111111-0000-0000-0000-000000000001',
+        NOW() - INTERVAL '45 days', 1.50, 1.20, 0.30, 10150000.00, NOW() - INTERVAL '45 days');
+
+-- Insert snapshot asset daily return
+INSERT INTO snapshot_asset_daily_returns (id, portfolio_id, snapshot_id, asset_id, return_date, weight_used,
+                                         asset_return_local, asset_return_total, fx_return, contribution_total, value_krw, calculated_at)
+VALUES ('44444444-0000-0000-0000-000000000001', 'eeeeeeee-0000-0000-0000-000000000001', '11111111-0000-0000-0000-000000000001',
+        'cccccccc-0000-0000-0000-000000000001', NOW() - INTERVAL '45 days', 50.00, 1.20, 1.50, 0.30, 0.75, 5075000.00, NOW() - INTERVAL '45 days');
+
+-- Insert arena session for old deleted portfolio
+INSERT INTO arena_sessions (id, portfolio_id, user_id, status, current_round, total_rounds, created_at, updated_at, completed_at)
+VALUES ('55555555-0000-0000-0000-000000000001', 'eeeeeeee-0000-0000-0000-000000000001', 'bbbbbbbb-0000-0000-0000-000000000001',
+        'COMPLETED', 10, 11, NOW() - INTERVAL '100 days', NOW() - INTERVAL '100 days', NOW() - INTERVAL '100 days');
+
+-- Insert arena round for old deleted portfolio
+INSERT INTO arena_rounds (id, session_id, round_number, round_type, created_at)
+VALUES ('66666666-0000-0000-0000-000000000001', '55555555-0000-0000-0000-000000000001', 1, 'ASSET', NOW() - INTERVAL '100 days');
+
+-- Insert arena round choices
+INSERT INTO arena_round_choices (round_id, asset_id)
+VALUES
+    ('66666666-0000-0000-0000-000000000001', 'cccccccc-0000-0000-0000-000000000001'),
+    ('66666666-0000-0000-0000-000000000001', 'dddddddd-0000-0000-0000-000000000001');
+
+-- Update arena round with selected asset
+UPDATE arena_rounds
+SET selected_asset_id = 'cccccccc-0000-0000-0000-000000000001',
+    picked_at = NOW() - INTERVAL '100 days'
+WHERE id = '66666666-0000-0000-0000-000000000001';
+
+-- Insert recent deleted portfolio (20 days ago) - should NOT be hard deleted
+INSERT INTO portfolios (id, user_id, name, status, started_at, created_at, updated_at, deleted_at)
+VALUES ('77777777-0000-0000-0000-000000000001', 'bbbbbbbb-0000-0000-0000-000000000001', 'Recent Deleted Portfolio', 'ACTIVE',
+        NOW() - INTERVAL '50 days', NOW() - INTERVAL '50 days', NOW() - INTERVAL '20 days', NOW() - INTERVAL '20 days');
+
+-- Insert active portfolio (not deleted) - should NOT be hard deleted
+INSERT INTO portfolios (id, user_id, name, status, started_at, created_at, updated_at)
+VALUES ('88888888-0000-0000-0000-000000000001', 'bbbbbbbb-0000-0000-0000-000000000001', 'Active Portfolio', 'ACTIVE',
+        NOW() - INTERVAL '100 days', NOW() - INTERVAL '100 days', NOW());

--- a/src/test/resources/sql/portfolio-guest-test-data.sql
+++ b/src/test/resources/sql/portfolio-guest-test-data.sql
@@ -1,0 +1,28 @@
+-- Test data for guest portfolio tests
+-- Clean up existing data
+DELETE FROM portfolio_assets WHERE portfolio_id IN (
+    SELECT id FROM portfolios WHERE guest_session_id = 'aaa00000-0000-0000-0000-000000000001'
+);
+DELETE FROM portfolios WHERE guest_session_id = 'aaa00000-0000-0000-0000-000000000001';
+DELETE FROM guest_sessions WHERE id = 'aaa00000-0000-0000-0000-000000000001';
+DELETE FROM assets WHERE symbol IN ('GUEST_TEST_KR', 'GUEST_TEST_US');
+
+-- Insert test guest session
+INSERT INTO guest_sessions (id, created_at, last_seen_at)
+VALUES ('aaa00000-0000-0000-0000-000000000001', NOW(), NOW());
+
+-- Insert test assets
+INSERT INTO assets (id, symbol, name, market, type, sector, current_risk_level, active, image_url, created_at, updated_at, as_of)
+VALUES
+    ('ccc00000-0000-0000-0000-000000000001', 'GUEST_TEST_KR', '게스트테스트한국주식', 'KR', 'STOCK', 'FINANCIALS', 2, true, NULL, NOW(), NOW(), NOW()),
+    ('ddd00000-0000-0000-0000-000000000001', 'GUEST_TEST_US', 'Guest Test US Stock', 'US', 'STOCK', 'ENERGY', 5, true, NULL, NOW(), NOW(), NOW());
+
+-- Insert test guest portfolio (ACTIVE)
+INSERT INTO portfolios (id, user_id, guest_session_id, name, status, started_at, created_at, updated_at)
+VALUES ('bbb00000-0000-0000-0000-000000000001', NULL, 'aaa00000-0000-0000-0000-000000000001', '게스트 테스트 포트폴리오', 'ACTIVE', '2024-01-01', NOW(), NOW());
+
+-- Insert portfolio assets
+INSERT INTO portfolio_assets (id, portfolio_id, asset_id, weight_pct)
+VALUES
+    ('eee00000-0000-0000-0000-000000000001', 'bbb00000-0000-0000-0000-000000000001', 'ccc00000-0000-0000-0000-000000000001', 60.00),
+    ('fff00000-0000-0000-0000-000000000001', 'bbb00000-0000-0000-0000-000000000001', 'ddd00000-0000-0000-0000-000000000001', 40.00);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 포트폴리오 삭제 API 추가: DELETE /portfolios/{portfolioId}로 소프트 삭제(30일 보관, 즉시 목록·편집 제외) 및 권한/인증 검증, 204 응답 지원
  * 메인 포트폴리오 삭제 방지 및 재지정 안내

* **Chores**
  * 만료된 소프트삭제 데이터 일괄 정리 배치 작업 추가(일별 스케줄, 30일 경과시 하드 삭제)
  * DB에 삭제 상태 추적용 컬럼 및 인덱스 추가

* **Tests**
  * 배치 및 삭제 관련 통합 테스트 추가 (다양한 삭제/보존 시나리오 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->