### PR TITLE
회원 탈퇴 API 추가

### DIFF
--- a/src/main/java/com/porcana/batch/job/PortfolioPerformanceBatchJob.java
+++ b/src/main/java/com/porcana/batch/job/PortfolioPerformanceBatchJob.java
@@ -86,7 +86,7 @@ public class PortfolioPerformanceBatchJob {
     }
 
     /**
-     * Reader: ACTIVE 포트폴리오를 페이징 방식으로 읽기
+     * Reader: ACTIVE 포트폴리오를 페이징 방식으로 읽기 (삭제된 포트폴리오 제외)
      */
     @Bean
     @StepScope
@@ -94,7 +94,7 @@ public class PortfolioPerformanceBatchJob {
         return new RepositoryItemReaderBuilder<Portfolio>()
                 .name("portfolioReader")
                 .repository(portfolioRepository)
-                .methodName("findByStatus")
+                .methodName("findByStatusAndDeletedAtIsNull")
                 .arguments(Collections.singletonList(PortfolioStatus.ACTIVE))
                 .pageSize(CHUNK_SIZE)
                 .sorts(Map.of("createdAt", Sort.Direction.ASC))

--- a/src/main/java/com/porcana/domain/arena/repository/ArenaSessionRepository.java
+++ b/src/main/java/com/porcana/domain/arena/repository/ArenaSessionRepository.java
@@ -68,4 +68,18 @@ public interface ArenaSessionRepository extends JpaRepository<ArenaSession, UUID
      * Returns the number of deleted sessions
      */
     int deleteByPortfolioId(UUID portfolioId);
+
+    // ===== User Cleanup Support =====
+
+    /**
+     * Find all sessions for a user
+     * Used for hard-deleting user's arena sessions on withdrawal
+     */
+    List<ArenaSession> findByUserId(UUID userId);
+
+    /**
+     * Delete all sessions for a user
+     * Returns the number of deleted sessions
+     */
+    int deleteByUserId(UUID userId);
 }

--- a/src/main/java/com/porcana/domain/arena/service/ArenaService.java
+++ b/src/main/java/com/porcana/domain/arena/service/ArenaService.java
@@ -524,4 +524,19 @@ public class ArenaService {
                 .currentRound(session.getCurrentRound())
                 .build();
     }
+
+    /**
+     * Delete all arena sessions for a user (hard delete)
+     * Called when user withdraws from the service
+     */
+    @Transactional
+    public void deleteAllSessionsForUser(UUID userId) {
+        List<ArenaSession> sessions = sessionRepository.findByUserId(userId);
+        for (ArenaSession session : sessions) {
+            // Delete rounds first (foreign key constraint)
+            roundRepository.deleteBySessionId(session.getId());
+        }
+        // Delete sessions (arena_session_sectors will be cascade deleted via @ElementCollection)
+        sessionRepository.deleteByUserId(userId);
+    }
 }

--- a/src/main/java/com/porcana/domain/arena/service/ArenaService.java
+++ b/src/main/java/com/porcana/domain/arena/service/ArenaService.java
@@ -478,7 +478,7 @@ public class ArenaService {
 
             // Set as main portfolio only for authenticated users
             if (session.getUserId() != null) {
-                User user = userRepository.findById(session.getUserId())
+                User user = userRepository.findByIdAndDeletedAtIsNull(session.getUserId())
                         .orElseThrow(() -> new IllegalArgumentException("User not found"));
                 if (user.getMainPortfolioId() == null) {
                     user.setMainPortfolioId(session.getPortfolioId());

--- a/src/main/java/com/porcana/domain/asset/service/AssetService.java
+++ b/src/main/java/com/porcana/domain/asset/service/AssetService.java
@@ -101,7 +101,7 @@ public class AssetService {
     }
 
     public AssetInMainPortfolioResponse isAssetInMainPortfolio(UUID assetId, UUID userId) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         UUID mainPortfolioId = user.getMainPortfolioId();

--- a/src/main/java/com/porcana/domain/auth/service/AuthService.java
+++ b/src/main/java/com/porcana/domain/auth/service/AuthService.java
@@ -79,7 +79,7 @@ public class AuthService {
      * Login with EMAIL provider
      */
     private User loginWithEmail(LoginCommand command) {
-        User user = userRepository.findByEmail(command.getEmail())
+        User user = userRepository.findByEmailAndDeletedAtIsNull(command.getEmail())
                 .orElseThrow(() -> new IllegalArgumentException("Invalid email or password"));
 
         if (user.getProvider() != User.AuthProvider.EMAIL || user.getPassword() == null) {
@@ -106,7 +106,7 @@ public class AuthService {
                 email.substring(0, Math.min(3, email.indexOf('@'))));
 
                 // Find existing user or create new one
-        Optional<User> existingUser = userRepository.findByEmail(email);
+        Optional<User> existingUser = userRepository.findByEmailAndDeletedAtIsNull(email);
 
         if (existingUser.isPresent()) {
             User user = existingUser.get();
@@ -142,7 +142,7 @@ public class AuthService {
         String baseNickname = email.split("@")[0];
 
         // Check if nickname exists
-        if (!userRepository.existsByNickname(baseNickname)) {
+        if (!userRepository.existsByNicknameAndDeletedAtIsNull(baseNickname)) {
             return baseNickname;
         }
 
@@ -152,7 +152,7 @@ public class AuthService {
         do {
             nickname = baseNickname + suffix;
             suffix++;
-        } while (userRepository.existsByNickname(nickname));
+        } while (userRepository.existsByNicknameAndDeletedAtIsNull(nickname));
 
         return nickname;
     }
@@ -170,7 +170,7 @@ public class AuthService {
 
         UUID userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
 
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         String newAccessToken = jwtTokenProvider.createAccessToken(user.getId());
@@ -210,7 +210,7 @@ public class AuthService {
             }
 
             // Set main portfolio if user doesn't have one
-            User user = userRepository.findById(userId)
+            User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                     .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
             if (user.getMainPortfolioId() == null && !guestPortfolios.isEmpty()) {

--- a/src/main/java/com/porcana/domain/home/service/HomeService.java
+++ b/src/main/java/com/porcana/domain/home/service/HomeService.java
@@ -34,7 +34,7 @@ public class HomeService {
     private final PortfolioSnapshotAssetRepository portfolioSnapshotAssetRepository;
 
     public HomeResponse getHome(UUID userId) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         UUID mainPortfolioId = user.getMainPortfolioId();
@@ -77,7 +77,7 @@ public class HomeService {
 
     @Transactional
     public MainPortfolioIdResponse setMainPortfolio(UUID userId, UUID portfolioId) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         Portfolio portfolio = portfolioRepository.findByIdAndUserIdAndDeletedAtIsNull(portfolioId, userId)

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -46,7 +46,7 @@ public class PortfolioService {
 
         if (userId != null) {
             // Authenticated user
-            User user = userRepository.findById(userId)
+            User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                     .orElseThrow(() -> new IllegalArgumentException("User not found"));
             portfolios = portfolioRepository.findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId);
             mainPortfolioId = user.getMainPortfolioId();
@@ -104,7 +104,7 @@ public class PortfolioService {
 
         boolean isMain = false;
         if (userId != null) {
-            User user = userRepository.findById(userId)
+            User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                     .orElseThrow(() -> new IllegalArgumentException("User not found"));
             isMain = portfolio.getId().equals(user.getMainPortfolioId());
         }
@@ -538,7 +538,7 @@ public class PortfolioService {
 
         // 메인 포트폴리오는 삭제 불가 - 먼저 메인을 변경해야 함
         if (userId != null) {
-            User user = userRepository.findById(userId)
+            User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                     .orElseThrow(() -> new IllegalArgumentException("User not found"));
             if (portfolioId.equals(user.getMainPortfolioId())) {
                 throw new IllegalStateException("Cannot delete main portfolio. Please change main portfolio first.");

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -549,6 +549,19 @@ public class PortfolioService {
         portfolioRepository.save(portfolio);
     }
 
+    /**
+     * Delete all portfolios for a user (soft delete)
+     * Called when user withdraws from the service
+     */
+    @Transactional
+    public void deleteAllPortfoliosForUser(UUID userId) {
+        List<Portfolio> portfolios = portfolioRepository.findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId);
+        for (Portfolio portfolio : portfolios) {
+            portfolio.delete();
+        }
+        portfolioRepository.saveAll(portfolios);
+    }
+
     @Transactional
     public UpdateAssetWeightsResponse updateAssetWeights(UpdateAssetWeightsCommand command) {
         Portfolio portfolio = portfolioRepository.findByIdAndUserIdAndDeletedAtIsNull(command.getPortfolioId(), command.getUserId())

--- a/src/main/java/com/porcana/domain/user/UserController.java
+++ b/src/main/java/com/porcana/domain/user/UserController.java
@@ -56,4 +56,18 @@ public class UserController {
         UserResponse response = userService.updateMe(userId, command);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "현재 로그인한 사용자의 계정과 사용자 소유 데이터를 삭제합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "탈퇴 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패")
+            }
+    )
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMe(@CurrentUser UUID userId) {
+        userService.deleteMe(userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/porcana/domain/user/entity/User.java
+++ b/src/main/java/com/porcana/domain/user/entity/User.java
@@ -44,6 +44,9 @@ public class User {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Builder
     public User(String email, String password, String nickname, AuthProvider provider) {
         this.email = email;
@@ -63,6 +66,18 @@ public class User {
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void delete() {
+        if (this.deletedAt != null) {
+            throw new IllegalStateException("User is already deleted");
+        }
+
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 
     public enum AuthProvider {

--- a/src/main/java/com/porcana/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/porcana/domain/user/repository/UserRepository.java
@@ -9,7 +9,10 @@ import java.util.UUID;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByIdAndDeletedAtIsNull(UUID id);
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
+    boolean existsByNicknameAndDeletedAtIsNull(String nickname);
 }

--- a/src/main/java/com/porcana/domain/user/service/UserService.java
+++ b/src/main/java/com/porcana/domain/user/service/UserService.java
@@ -15,10 +15,9 @@ import java.util.UUID;
 public class UserService {
 
     private final UserRepository userRepository;
-
     @Transactional(readOnly = true)
     public UserResponse getMe(UUID userId) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         return UserResponse.from(user);
@@ -26,11 +25,19 @@ public class UserService {
 
     @Transactional
     public UserResponse updateMe(UUID userId, UpdateUserCommand command) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         user.updateNickname(command.getNickname());
 
         return UserResponse.from(user);
+    }
+
+    @Transactional
+    public void deleteMe(UUID userId) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        user.delete();
     }
 }

--- a/src/main/java/com/porcana/domain/user/service/UserService.java
+++ b/src/main/java/com/porcana/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.porcana.domain.user.service;
 
+import com.porcana.domain.arena.service.ArenaService;
+import com.porcana.domain.portfolio.service.PortfolioService;
 import com.porcana.domain.user.command.UpdateUserCommand;
 import com.porcana.domain.user.dto.UserResponse;
 import com.porcana.domain.user.entity.User;
@@ -15,6 +17,8 @@ import java.util.UUID;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PortfolioService portfolioService;
+    private final ArenaService arenaService;
     @Transactional(readOnly = true)
     public UserResponse getMe(UUID userId) {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
@@ -37,6 +41,12 @@ public class UserService {
     public void deleteMe(UUID userId) {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        // 회원의 아레나 세션 hard delete (ArenaRound 포함)
+        arenaService.deleteAllSessionsForUser(userId);
+
+        // 회원의 포트폴리오 soft delete
+        portfolioService.deleteAllPortfoliosForUser(userId);
 
         user.delete();
     }

--- a/src/main/java/com/porcana/global/security/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/porcana/global/security/CurrentUserArgumentResolver.java
@@ -1,5 +1,7 @@
 package com.porcana.global.security;
 
+import com.porcana.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
@@ -14,7 +16,10 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import java.util.UUID;
 
 @Component
+@RequiredArgsConstructor
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserRepository userRepository;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -40,6 +45,10 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
             );
         }
 
-        return (UUID) principal;
+        UUID userId = (UUID) principal;
+        userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new AuthenticationCredentialsNotFoundException("User is not active"));
+
+        return userId;
     }
 }

--- a/src/main/resources/db/migration/V21__add_deleted_at_to_users.sql
+++ b/src/main/resources/db/migration/V21__add_deleted_at_to_users.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users ADD COLUMN deleted_at TIMESTAMP NULL;
+
+CREATE INDEX idx_users_deleted_at ON users(deleted_at);
+
+COMMENT ON COLUMN users.deleted_at IS 'Soft delete timestamp. NULL means active user.';

--- a/src/test/java/com/porcana/domain/user/UserControllerTest.java
+++ b/src/test/java/com/porcana/domain/user/UserControllerTest.java
@@ -2,6 +2,8 @@ package com.porcana.domain.user;
 
 import com.porcana.BaseIntegrationTest;
 import com.porcana.domain.user.dto.UpdateUserRequest;
+import com.porcana.domain.user.entity.User;
+import com.porcana.domain.user.repository.UserRepository;
 import com.porcana.global.security.JwtTokenProvider;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
@@ -12,23 +14,27 @@ import org.springframework.test.context.jdbc.Sql;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Sql(scripts = "/sql/user-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 class UserControllerTest extends BaseIntegrationTest {
 
+    private static final UUID TEST_USER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    // Test user ID from SQL file
-    private static final UUID TEST_USER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    @Autowired
+    private UserRepository userRepository;
 
     private String createAccessToken() {
         return jwtTokenProvider.createAccessToken(TEST_USER_ID);
     }
 
     @Test
-    @DisplayName("내 정보 조회 성공")
+    @DisplayName("get me success")
     void getMe_success() {
         String accessToken = createAccessToken();
 
@@ -37,15 +43,14 @@ class UserControllerTest extends BaseIntegrationTest {
         .when()
                 .get("/me")
         .then()
-                .log().all()
                 .statusCode(200)
                 .body("userId", equalTo(TEST_USER_ID.toString()))
-                .body("nickname", equalTo("테스터"))
+                .body("nickname", equalTo("tester"))
                 .body("mainPortfolioId", nullValue());
     }
 
     @Test
-    @DisplayName("내 정보 조회 실패 - 인증 없음")
+    @DisplayName("get me fails without auth")
     void getMe_fail_noAuth() {
         given()
         .when()
@@ -55,7 +60,7 @@ class UserControllerTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("내 정보 조회 실패 - 유효하지 않은 토큰")
+    @DisplayName("get me fails with invalid token")
     void getMe_fail_invalidToken() {
         given()
                 .header("Authorization", "Bearer invalid-token")
@@ -66,11 +71,11 @@ class UserControllerTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("내 정보 수정 성공")
+    @DisplayName("update me success")
     void updateMe_success() {
         String accessToken = createAccessToken();
 
-        UpdateUserRequest updateRequest = new UpdateUserRequest("새닉네임");
+        UpdateUserRequest updateRequest = new UpdateUserRequest("updated-user");
 
         given()
                 .header("Authorization", "Bearer " + accessToken)
@@ -79,14 +84,13 @@ class UserControllerTest extends BaseIntegrationTest {
         .when()
                 .patch("/me")
         .then()
-                .log().all()
                 .statusCode(200)
                 .body("userId", equalTo(TEST_USER_ID.toString()))
-                .body("nickname", equalTo("새닉네임"));
+                .body("nickname", equalTo("updated-user"));
     }
 
     @Test
-    @DisplayName("내 정보 수정 실패 - validation 오류 (빈 닉네임)")
+    @DisplayName("update me fails on blank nickname")
     void updateMe_fail_blankNickname() {
         String accessToken = createAccessToken();
 
@@ -103,9 +107,9 @@ class UserControllerTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("내 정보 수정 실패 - 인증 없음")
+    @DisplayName("update me fails without auth")
     void updateMe_fail_noAuth() {
-        UpdateUserRequest updateRequest = new UpdateUserRequest("새닉네임");
+        UpdateUserRequest updateRequest = new UpdateUserRequest("updated-user");
 
         given()
                 .contentType(ContentType.JSON)
@@ -117,12 +121,11 @@ class UserControllerTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("내 정보 수정 후 조회하면 변경된 닉네임 확인")
+    @DisplayName("update me persists")
     void updateMe_then_getMe() {
         String accessToken = createAccessToken();
 
-        // 닉네임 수정
-        UpdateUserRequest updateRequest = new UpdateUserRequest("변경된닉네임");
+        UpdateUserRequest updateRequest = new UpdateUserRequest("persisted-user");
 
         given()
                 .header("Authorization", "Bearer " + accessToken)
@@ -133,13 +136,39 @@ class UserControllerTest extends BaseIntegrationTest {
         .then()
                 .statusCode(200);
 
-        // 조회해서 확인
         given()
                 .header("Authorization", "Bearer " + accessToken)
         .when()
                 .get("/me")
         .then()
                 .statusCode(200)
-                .body("nickname", equalTo("변경된닉네임"));
+                .body("nickname", equalTo("persisted-user"));
+    }
+
+    @Test
+    @DisplayName("delete me success")
+    void deleteMe_success() {
+        String accessToken = createAccessToken();
+
+        assertTrue(userRepository.existsById(TEST_USER_ID));
+        assertTrue(userRepository.findByIdAndDeletedAtIsNull(TEST_USER_ID).isPresent());
+
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .delete("/me")
+        .then()
+                .statusCode(204);
+
+        User deletedUser = userRepository.findById(TEST_USER_ID).orElseThrow();
+        assertTrue(deletedUser.isDeleted());
+        assertTrue(userRepository.findByIdAndDeletedAtIsNull(TEST_USER_ID).isEmpty());
+
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .get("/me")
+        .then()
+                .statusCode(401);
     }
 }

--- a/src/test/resources/sql/user-test-data.sql
+++ b/src/test/resources/sql/user-test-data.sql
@@ -1,6 +1,55 @@
--- Test user data for UserControllerTest
--- Password is stored as plain text because passwordEncoder is mocked
-DELETE FROM users WHERE email = 'test@example.com';
+DELETE FROM arena_sessions WHERE user_id = '550e8400-e29b-41d4-a716-446655440000';
+DELETE FROM portfolios WHERE user_id = '550e8400-e29b-41d4-a716-446655440000';
+DELETE FROM users WHERE id = '550e8400-e29b-41d4-a716-446655440000';
 
-INSERT INTO users (id, email, password, nickname, provider, main_portfolio_id, created_at, updated_at)
-VALUES ('550e8400-e29b-41d4-a716-446655440000', 'test@example.com', 'password123', '테스터', 'EMAIL', NULL, NOW(), NOW());
+INSERT INTO users (id, email, password, nickname, provider, main_portfolio_id, created_at, updated_at, deleted_at)
+VALUES (
+    '550e8400-e29b-41d4-a716-446655440000',
+    'test@example.com',
+    'password123',
+    'tester',
+    'EMAIL',
+    NULL,
+    NOW(),
+    NOW(),
+    NULL
+);
+
+INSERT INTO portfolios (id, user_id, name, status, started_at, created_at, updated_at, deleted_at)
+VALUES (
+    '11111111-1111-1111-1111-111111111111',
+    '550e8400-e29b-41d4-a716-446655440000',
+    'Test Portfolio',
+    'DRAFT',
+    NULL,
+    NOW(),
+    NOW(),
+    NULL
+);
+
+INSERT INTO arena_sessions (
+    id,
+    portfolio_id,
+    user_id,
+    guest_session_id,
+    status,
+    current_round,
+    total_rounds,
+    risk_profile,
+    created_at,
+    updated_at,
+    completed_at
+)
+VALUES (
+    '22222222-2222-2222-2222-222222222222',
+    '11111111-1111-1111-1111-111111111111',
+    '550e8400-e29b-41d4-a716-446655440000',
+    NULL,
+    'IN_PROGRESS',
+    1,
+    11,
+    NULL,
+    NOW(),
+    NOW(),
+    NULL
+);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 자신의 계정을 삭제할 수 있는 기능 추가 (DELETE /api/v1/me)

* **버그 수정 / 동작 변경**
  * 삭제된(비활성) 사용자는 로그인·조회·별명 검사 등에서 제외되어 더 이상 인증/검색 대상이 아님

* **데이터베이스**
  * 사용자 테이블에 soft-delete 컬럼 추가(활성/삭제 구분)

* **테스트**
  * 계정 삭제 흐름 및 관련 조회/업데이트 통합 테스트 추가/갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->