### PR TITLE
일일 배치 시간 비슷하게 통일 & 비중 수정 API 시간대 제한 추가

### DIFF
--- a/.claude/skills/batch-jobs/SKILL.md
+++ b/.claude/skills/batch-jobs/SKILL.md
@@ -31,33 +31,28 @@ disable-model-invocation: false
 ./gradlew bootRun --args='--spring.batch.job.names=assetRiskJob'
 ```
 
-### 일일 스케줄 (평일)
+### 일일 스케줄 (화-토, 07:00~07:30 KST)
 
-**07:00 KST (화-토) - 미국 시장 가격 업데이트**
+> **사용자 안내**: "수익률은 매일 오전 7시 30분에 업데이트됩니다"
+
+**07:00 KST - 한국/미국 가격 업데이트**
 ```bash
-# 미국 주식 가격
-./gradlew bootRun --args='--spring.batch.job.names=usDailyPriceJob'
+# 한국 주식/ETF 가격
+./gradlew bootRun --args='--spring.batch.job.names=krDailyPriceJob'
+./gradlew bootRun --args='--spring.batch.job.names=krEtfDailyPriceJob'
 
-# 미국 ETF 가격
+# 미국 주식/ETF 가격
+./gradlew bootRun --args='--spring.batch.job.names=usDailyPriceJob'
 ./gradlew bootRun --args='--spring.batch.job.names=usEtfDailyPriceJob'
 ```
 
-**12:00 KST (월-금) - 환율 업데이트**
+**07:15 KST - 환율 업데이트 (전일 환율)**
 ```bash
-# 환율 데이터
+# 환율 데이터 (전일 환율 조회)
 ./gradlew bootRun --args='--spring.batch.job.names=exchangeRateJob'
 ```
 
-**18:00 KST (월-금) - 한국 시장 가격 업데이트**
-```bash
-# 한국 주식 가격
-./gradlew bootRun --args='--spring.batch.job.names=krDailyPriceJob'
-
-# 한국 ETF 가격
-./gradlew bootRun --args='--spring.batch.job.names=krEtfDailyPriceJob'
-```
-
-**19:00 KST (매일) - 포트폴리오 수익률 계산**
+**07:30 KST - 포트폴리오 수익률 계산**
 ```bash
 # 포트폴리오 일별 수익률 계산
 ./gradlew bootRun --args='--spring.batch.job.names=portfolioPerformanceJob'
@@ -181,13 +176,23 @@ riskScore = 100 × (0.45 × volPct + 0.45 × mddPct + 0.10 × worstPct)
 ## Batch 스케줄링 설정
 
 ```java
-// 한국 시장: 평일 18:00 KST
-@Scheduled(cron = "0 0 18 * * MON-FRI", zone = "Asia/Seoul")
+// 일일 스케줄 (화-토, 07:00~07:30 KST)
+// → 사용자 안내: "수익률은 매일 오전 7시 30분에 업데이트됩니다"
+
+// 07:00 - 한국/미국 가격
+@Scheduled(cron = "0 0 7 * * TUE-SAT", zone = "Asia/Seoul")
 public void runKrDailyPriceUpdate()
 
-// 미국 시장: 평일 07:00 KST (화-토, 시차 고려)
 @Scheduled(cron = "0 0 7 * * TUE-SAT", zone = "Asia/Seoul")
 public void runUsDailyPriceUpdate()
+
+// 07:15 - 환율 (전일 환율)
+@Scheduled(cron = "0 15 7 * * TUE-SAT", zone = "Asia/Seoul")
+public void runExchangeRateUpdate()
+
+// 07:30 - 포트폴리오 수익률
+@Scheduled(cron = "0 30 7 * * TUE-SAT", zone = "Asia/Seoul")
+public void runPortfolioPerformanceCalculation()
 ```
 
 ## 포트폴리오 수익률 계산 (Portfolio Performance Batch)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,16 +188,15 @@ public ResponseEntity<UserResponse> getMe(@CurrentUser UUID userId) {
 **03:00 KST - 위험도 계산**
 - assetRiskJob (전 종목 위험도 계산)
 
-### 일일 스케줄 (평일)
+### 일일 스케줄 (화-토, 07:00~07:30 KST)
 
-**07:00 KST (화-토) - 미국 시장**
-- usDailyPriceJob, usEtfDailyPriceJob
+> **사용자 안내**: "수익률은 매일 오전 7시 30분에 업데이트됩니다"
 
-**12:00 KST (월-금) - 환율**
-- exchangeRateJob
-
-**18:00 KST (월-금) - 한국 시장**
-- krDailyPriceJob, krEtfDailyPriceJob
+| 시간 | 작업 | Job |
+|------|------|-----|
+| 07:00 | 한국/미국 가격 | krDailyPriceJob, usDailyPriceJob, krEtfDailyPriceJob, usEtfDailyPriceJob |
+| 07:15 | 환율 (전일) | exchangeRateJob |
+| 07:30 | 포트폴리오 수익률 | portfolioPerformanceJob |
 
 ### 배치 모니터링
 

--- a/src/main/java/com/porcana/batch/config/BatchConfig.java
+++ b/src/main/java/com/porcana/batch/config/BatchConfig.java
@@ -15,10 +15,17 @@ import org.springframework.scheduling.annotation.Scheduled;
  * Spring Batch configuration
  * <p>
  * Enables batch processing infrastructure and provides common batch settings
- * Includes scheduled jobs for:
- * - Weekly asset updates (stocks and ETFs)
- * - Daily price updates (stocks and ETFs)
- * - Daily exchange rate updates
+ *
+ * 일일 업데이트 스케줄 (KST, 화-토):
+ * - 07:00 한국/미국 가격
+ * - 07:15 환율 (전일 환율)
+ * - 07:30 포트폴리오 수익률
+ *
+ * 주간 스케줄 (일요일):
+ * - 02:00 종목 데이터 업데이트
+ * - 03:00 위험도 계산
+ *
+ * → 사용자 안내: "수익률은 매일 오전 7시 30분에 업데이트됩니다"
  */
 @Slf4j
 @Configuration
@@ -212,10 +219,9 @@ public class BatchConfig {
 
     /**
      * Scheduled exchange rate update job
-     * Runs every weekday at 12:00 KST
-     * Korea Exim Bank updates exchange rates around 10:00 KST
+     * Runs every TUE-SAT at 07:15 KST (fetches previous day's rate)
      */
-    @Scheduled(cron = "0 0 12 * * MON-FRI", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 15 7 * * TUE-SAT", zone = "Asia/Seoul")
     public void runExchangeRateUpdate() {
         log.info("Starting scheduled exchange rate update");
 
@@ -257,10 +263,12 @@ public class BatchConfig {
 
     /**
      * Scheduled portfolio performance calculation job
-     * Runs every day at 08:00 KST (after US market price update at 07:00)
+     * Runs every TUE-SAT at 07:30 KST (after price updates at 07:00 and exchange rate at 07:15)
      * Calculates daily returns for all ACTIVE portfolios
+     *
+     * 사용자 안내: "수익률은 매일 오전 7시 30분에 업데이트됩니다"
      */
-    @Scheduled(cron = "0 0 8 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 30 7 * * TUE-SAT", zone = "Asia/Seoul")
     public void runPortfolioPerformanceCalculation() {
         log.info("Starting scheduled portfolio performance calculation");
 

--- a/src/main/java/com/porcana/batch/job/ExchangeRateBatchJob.java
+++ b/src/main/java/com/porcana/batch/job/ExchangeRateBatchJob.java
@@ -25,6 +25,9 @@ import java.util.Map;
 /**
  * Daily exchange rate update batch job
  * Fetches and updates exchange rates from Korea Exim Bank API
+ *
+ * 매일 07:15 KST에 실행되며, 전일 환율을 가져옴
+ * (한국수출입은행은 당일 환율을 오전 11시경에 제공하므로 전일 환율 사용)
  */
 @Slf4j
 @Configuration
@@ -65,12 +68,13 @@ public class ExchangeRateBatchJob {
                         log.info("timestamp parameter is null, using current time: {}", timestamp);
                     }
 
-                    // Convert timestamp to LocalDate (KST timezone)
-                    LocalDate targetDate = Instant.ofEpochMilli(timestamp)
+                    // Convert timestamp to LocalDate (KST timezone) and get previous day
+                    LocalDate today = Instant.ofEpochMilli(timestamp)
                             .atZone(ZoneId.of("Asia/Seoul"))
                             .toLocalDate();
+                    LocalDate targetDate = today.minusDays(1);
 
-                    log.info("Using target date from JobParameters: {}", targetDate);
+                    log.info("Fetching exchange rate for previous day: {} (today: {})", targetDate, today);
 
                     try {
                         List<ExchangeRate> exchangeRates = koreaEximProvider.fetchExchangeRates(targetDate);

--- a/src/main/java/com/porcana/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/porcana/batch/scheduler/BatchScheduler.java
@@ -17,6 +17,14 @@ import java.time.ZonedDateTime;
 /**
  * Scheduler for batch jobs
  * Executes batch jobs at scheduled intervals
+ *
+ * 일일 업데이트 스케줄 (KST):
+ * - 07:00 미국 가격 (화-토, 미국 장 마감 후)
+ * - 07:15 환율 (월-금)
+ * - 07:30 포트폴리오 수익률 (매일)
+ * - 22:00 한국 가격 (월-금, 한국 장 마감 후)
+ *
+ * → 사용자 안내: "수익률은 매일 오전 7시 30분에 업데이트됩니다"
  */
 @Slf4j
 @Component
@@ -220,13 +228,13 @@ public class BatchScheduler {
      * Execute exchange rate update batch job every 24 hours
      * Uncomment @Scheduled annotation to enable
      */
-//    @Scheduled(fixedDelay = 86400000) // 24 hours = 86,400,000 ms
+    @Scheduled(fixedDelay = 86400000) // 24 hours = 86,400,000 ms
     public void runExchangeRateBatch() {
         try {
             log.info("Starting scheduled exchange rate update batch job");
 
             // Use specific date/time: 2026-01-22 08:00 KST
-            ZonedDateTime targetDateTime = ZonedDateTime.of(2026, 1, 21, 12, 0, 1, 0, ZoneId.of("Asia/Seoul"));
+            ZonedDateTime targetDateTime = ZonedDateTime.of(2026, 3, 13, 12, 0, 1, 0, ZoneId.of("Asia/Seoul"));
             JobParameters jobParameters = new JobParametersBuilder()
                     .addLong("timestamp", targetDateTime.toInstant().toEpochMilli())
                     .toJobParameters();

--- a/src/main/java/com/porcana/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/porcana/batch/scheduler/BatchScheduler.java
@@ -228,7 +228,7 @@ public class BatchScheduler {
      * Execute exchange rate update batch job every 24 hours
      * Uncomment @Scheduled annotation to enable
      */
-    @Scheduled(fixedDelay = 86400000) // 24 hours = 86,400,000 ms
+//    @Scheduled(fixedDelay = 86400000) // 24 hours = 86,400,000 ms
     public void runExchangeRateBatch() {
         try {
             log.info("Starting scheduled exchange rate update batch job");

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -640,11 +641,14 @@ public class PortfolioService {
     private void validateNotInBatchWindow() {
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
         LocalTime currentTime = now.toLocalTime();
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
 
         LocalTime batchStart = LocalTime.of(7, 0);
         LocalTime batchEnd = LocalTime.of(7, 45);
+        boolean isBatchDay = dayOfWeek.getValue() >= DayOfWeek.TUESDAY.getValue()
+                && dayOfWeek.getValue() <= DayOfWeek.SATURDAY.getValue();
 
-        if (!currentTime.isBefore(batchStart) && currentTime.isBefore(batchEnd)) {
+        if (isBatchDay && !currentTime.isBefore(batchStart) && currentTime.isBefore(batchEnd)) {
             throw new IllegalStateException(
                     "비중 수정은 오전 7:00~7:45 사이에 불가능합니다. 수익률 업데이트 중입니다."
             );

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -21,6 +21,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.EnumSet;
 import java.util.stream.Collectors;
 
 @Service
@@ -40,6 +41,13 @@ public class PortfolioService {
     private final PortfolioSnapshotAssetRepository portfolioSnapshotAssetRepository;
 
     private static final int MAX_GUEST_PORTFOLIOS = 3;
+
+    // 비중 수정 제한 시간대 (배치 실행 시간)
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final LocalTime WEIGHT_UPDATE_BLOCK_START = LocalTime.of(7, 0);
+    private static final LocalTime WEIGHT_UPDATE_BLOCK_END = LocalTime.of(7, 45);
+    private static final EnumSet<DayOfWeek> WEIGHT_UPDATE_BLOCK_DAYS =
+            EnumSet.range(DayOfWeek.TUESDAY, DayOfWeek.SATURDAY);
 
     /**
      * Get portfolios for user or guest session
@@ -639,16 +647,15 @@ public class PortfolioService {
      * 수익률 계산 배치가 07:00~07:30에 실행되므로 데이터 정합성을 위해 제한
      */
     private void validateNotInBatchWindow() {
-        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        ZonedDateTime now = ZonedDateTime.now(SEOUL);
         LocalTime currentTime = now.toLocalTime();
         DayOfWeek dayOfWeek = now.getDayOfWeek();
 
-        LocalTime batchStart = LocalTime.of(7, 0);
-        LocalTime batchEnd = LocalTime.of(7, 45);
-        boolean isBatchDay = dayOfWeek.getValue() >= DayOfWeek.TUESDAY.getValue()
-                && dayOfWeek.getValue() <= DayOfWeek.SATURDAY.getValue();
+        boolean isBatchDay = WEIGHT_UPDATE_BLOCK_DAYS.contains(dayOfWeek);
+        boolean isInBlockTime = !currentTime.isBefore(WEIGHT_UPDATE_BLOCK_START)
+                && currentTime.isBefore(WEIGHT_UPDATE_BLOCK_END);
 
-        if (isBatchDay && !currentTime.isBefore(batchStart) && currentTime.isBefore(batchEnd)) {
+        if (isBatchDay && isInBlockTime) {
             throw new IllegalStateException(
                     "비중 수정은 오전 7:00~7:45 사이에 불가능합니다. 수익률 업데이트 중입니다."
             );

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -16,6 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -564,6 +567,9 @@ public class PortfolioService {
 
     @Transactional
     public UpdateAssetWeightsResponse updateAssetWeights(UpdateAssetWeightsCommand command) {
+        // 배치 실행 시간대(07:00~07:45 KST)에는 비중 수정 불가
+        validateNotInBatchWindow();
+
         Portfolio portfolio = portfolioRepository.findByIdAndUserIdAndDeletedAtIsNull(command.getPortfolioId(), command.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("Portfolio not found or access denied"));
 
@@ -625,6 +631,24 @@ public class PortfolioService {
             case "1Y" -> endDate.minusYears(1);
             default -> endDate.minusMonths(1);
         };
+    }
+
+    /**
+     * 배치 실행 시간대(07:00~07:45 KST)에는 비중 수정을 막음
+     * 수익률 계산 배치가 07:00~07:30에 실행되므로 데이터 정합성을 위해 제한
+     */
+    private void validateNotInBatchWindow() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalTime currentTime = now.toLocalTime();
+
+        LocalTime batchStart = LocalTime.of(7, 0);
+        LocalTime batchEnd = LocalTime.of(7, 45);
+
+        if (!currentTime.isBefore(batchStart) && currentTime.isBefore(batchEnd)) {
+            throw new IllegalStateException(
+                    "비중 수정은 오전 7:00~7:45 사이에 불가능합니다. 수익률 업데이트 중입니다."
+            );
+        }
     }
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 변경**
  * 일일 업데이트 일정이 화-토 07:00~07:30 KST로 재정의
  * 07:00 한국/미국 주식·ETF 가격, 07:15 전일 환율 조회, 07:30 포트폴리오 수익률로 통합 표기
  * 사용자 안내 문구: “수익률은 매일 오전 7시 30분에 업데이트됩니다” 추가

* **개선 사항**
  * 배치 실행 윈도우(화-토 07:00~07:45) 동안 자산 비중 변경을 차단해 데이터 일관성 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->