### PR TITLE
직접 라이브러리에서 포트폴리오 생성 기능 추가

### DIFF
--- a/.claude/skills/api-specs/SKILL.md
+++ b/.claude/skills/api-specs/SKILL.md
@@ -288,6 +288,65 @@ Response (201 Created)
 }
 ```
 
+### POST /portfolios/direct
+**Description**: 종목과 비중을 직접 입력하여 포트폴리오를 생성합니다. 아레나 드래프트 방식이 아닌 직접 생성 방식입니다.
+
+**Auth**: Optional (JWT 또는 Guest Session)
+
+**소유권 결정:**
+- `Authorization` 헤더가 있으면 → 사용자 소유 (`user_id` 설정)
+- 없으면 → 게스트 소유 (`guest_session_id` 설정)
+
+**게스트 제한:**
+- 게스트당 최대 3개 포트폴리오
+
+**비중 처리:**
+- `weightPct`가 모두 null이면 → 1/n 균등 배분
+- `weightPct`가 하나라도 있으면 → 모든 종목에 비중 필수, 합계 100% 검증
+
+Request (비중 직접 입력)
+```json
+{
+  "name": "내 포트폴리오",
+  "assets": [
+    { "assetId": "uuid", "weightPct": 30.0 },
+    { "assetId": "uuid", "weightPct": 40.0 },
+    { "assetId": "uuid", "weightPct": 30.0 }
+  ]
+}
+```
+
+Request (균등 배분 - 비중 생략)
+```json
+{
+  "name": "내 포트폴리오",
+  "assets": [
+    { "assetId": "uuid" },
+    { "assetId": "uuid" },
+    { "assetId": "uuid" }
+  ]
+}
+```
+
+Response (201 Created)
+```json
+{
+  "portfolioId": "uuid",
+  "name": "string",
+  "status": "ACTIVE",
+  "createdAt": "YYYY-MM-DD"
+}
+```
+
+**Notes:**
+- 아레나 방식과 달리 즉시 ACTIVE 상태로 생성됨
+- **종목 개수: 5~20개** (최소 5개, 최대 20개)
+- 비중 입력 시 합계 100% 필수
+
+Error Responses
+- 400: 종목 개수가 5~20개 범위 밖, 비중 합계가 100%가 아님, 존재하지 않는 종목
+- 403: 게스트 포트폴리오 개수 초과
+
 ### GET /portfolios/{portfolioId}
 Response
 ```json

--- a/src/main/java/com/porcana/domain/asset/AssetRepository.java
+++ b/src/main/java/com/porcana/domain/asset/AssetRepository.java
@@ -27,6 +27,11 @@ public interface AssetRepository extends JpaRepository<Asset, UUID>, AssetReposi
     boolean existsBySymbolAndMarket(String symbol, Asset.Market market);
 
     /**
+     * Count assets by IDs (for bulk existence check)
+     */
+    long countByIdIn(List<UUID> ids);
+
+    /**
      * Find assets by market that were created after a specific timestamp
      * Used to fetch recently created assets for historical price backfilling
      */

--- a/src/main/java/com/porcana/domain/portfolio/PortfolioController.java
+++ b/src/main/java/com/porcana/domain/portfolio/PortfolioController.java
@@ -1,6 +1,7 @@
 package com.porcana.domain.portfolio;
 
 import com.porcana.domain.portfolio.command.CreatePortfolioCommand;
+import com.porcana.domain.portfolio.command.DirectCreatePortfolioCommand;
 import com.porcana.domain.portfolio.command.UpdateAssetWeightsCommand;
 import com.porcana.domain.portfolio.command.UpdatePortfolioNameCommand;
 import com.porcana.domain.portfolio.dto.*;
@@ -73,6 +74,26 @@ public class PortfolioController {
 
         CreatePortfolioCommand command = CreatePortfolioCommand.from(request, userId);
         CreatePortfolioResponse response = portfolioService.createPortfolio(command, userId, guestSessionId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "포트폴리오 직접 생성",
+            description = "종목과 비중을 직접 입력하여 포트폴리오를 생성합니다. 비중을 입력하지 않으면 1/n 균등 배분됩니다. 즉시 ACTIVE 상태로 생성됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "생성 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청 (비중 합계 오류, 종목 없음 등)", content = @Content)
+            }
+    )
+    @PostMapping("/direct")
+    public ResponseEntity<CreatePortfolioResponse> createPortfolioDirect(
+            @Valid @RequestBody DirectCreatePortfolioRequest request,
+            HttpServletRequest httpRequest) {
+        UUID userId = extractUserId();
+        UUID guestSessionId = guestSessionExtractor.extractGuestSessionId(httpRequest);
+
+        DirectCreatePortfolioCommand command = DirectCreatePortfolioCommand.from(request, userId);
+        CreatePortfolioResponse response = portfolioService.createPortfolioDirect(command, userId, guestSessionId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/porcana/domain/portfolio/command/DirectCreatePortfolioCommand.java
+++ b/src/main/java/com/porcana/domain/portfolio/command/DirectCreatePortfolioCommand.java
@@ -1,0 +1,39 @@
+package com.porcana.domain.portfolio.command;
+
+import com.porcana.domain.portfolio.dto.DirectCreatePortfolioRequest;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class DirectCreatePortfolioCommand {
+    private final UUID userId;
+    private final String name;
+    private final List<AssetWeight> assets;
+
+    @Getter
+    @Builder
+    public static class AssetWeight {
+        private final UUID assetId;
+        private final BigDecimal weightPct; // nullable - null이면 1/n 균등 배분
+    }
+
+    public static DirectCreatePortfolioCommand from(DirectCreatePortfolioRequest request, UUID userId) {
+        List<AssetWeight> assets = request.assets().stream()
+                .map(input -> AssetWeight.builder()
+                        .assetId(input.assetId())
+                        .weightPct(input.weightPct())
+                        .build())
+                .toList();
+
+        return DirectCreatePortfolioCommand.builder()
+                .userId(userId)
+                .name(request.name())
+                .assets(assets)
+                .build();
+    }
+}

--- a/src/main/java/com/porcana/domain/portfolio/dto/DirectCreatePortfolioRequest.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/DirectCreatePortfolioRequest.java
@@ -1,6 +1,8 @@
 package com.porcana.domain.portfolio.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
@@ -16,9 +18,11 @@ public record DirectCreatePortfolioRequest(
         String name,
 
         @Size(min = 5, max = 20, message = "종목 개수는 5~20개 사이여야 합니다")
+        @Valid
         List<AssetInput> assets
 ) {
     public record AssetInput(
+            @NotNull(message = "자산 ID는 필수입니다")
             UUID assetId,
             /**
              * 비중 (optional)

--- a/src/main/java/com/porcana/domain/portfolio/dto/DirectCreatePortfolioRequest.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/DirectCreatePortfolioRequest.java
@@ -1,6 +1,8 @@
 package com.porcana.domain.portfolio.dto;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -30,6 +32,8 @@ public record DirectCreatePortfolioRequest(
              * - null이면 1/n 균등 배분
              * - 값이 있으면 해당 비중 적용 (전체 합 100% 필수)
              */
+            @DecimalMin(value = "0", inclusive = false, message = "비중은 0보다 커야 합니다")
+            @DecimalMax(value = "100", message = "비중은 100 이하여야 합니다")
             BigDecimal weightPct
     ) {}
 }

--- a/src/main/java/com/porcana/domain/portfolio/dto/DirectCreatePortfolioRequest.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/DirectCreatePortfolioRequest.java
@@ -1,7 +1,7 @@
 package com.porcana.domain.portfolio.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -15,7 +15,7 @@ public record DirectCreatePortfolioRequest(
         @NotBlank(message = "포트폴리오 이름은 필수입니다")
         String name,
 
-        @NotEmpty(message = "최소 1개 이상의 종목이 필요합니다")
+        @Size(min = 5, max = 20, message = "종목 개수는 5~20개 사이여야 합니다")
         List<AssetInput> assets
 ) {
     public record AssetInput(

--- a/src/main/java/com/porcana/domain/portfolio/dto/DirectCreatePortfolioRequest.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/DirectCreatePortfolioRequest.java
@@ -17,6 +17,7 @@ public record DirectCreatePortfolioRequest(
         @NotBlank(message = "포트폴리오 이름은 필수입니다")
         String name,
 
+        @NotNull(message = "종목 목록은 필수입니다.")
         @Size(min = 5, max = 20, message = "종목 개수는 5~20개 사이여야 합니다")
         @Valid
         List<AssetInput> assets

--- a/src/main/java/com/porcana/domain/portfolio/dto/DirectCreatePortfolioRequest.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/DirectCreatePortfolioRequest.java
@@ -1,0 +1,30 @@
+package com.porcana.domain.portfolio.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 직접 종목/비중을 입력하여 포트폴리오 생성하는 요청
+ * 아레나 방식이 아닌 직접 생성 방식
+ */
+public record DirectCreatePortfolioRequest(
+        @NotBlank(message = "포트폴리오 이름은 필수입니다")
+        String name,
+
+        @NotEmpty(message = "최소 1개 이상의 종목이 필요합니다")
+        List<AssetInput> assets
+) {
+    public record AssetInput(
+            UUID assetId,
+            /**
+             * 비중 (optional)
+             * - null이면 1/n 균등 배분
+             * - 값이 있으면 해당 비중 적용 (전체 합 100% 필수)
+             */
+            BigDecimal weightPct
+    ) {}
+}

--- a/src/main/java/com/porcana/domain/portfolio/entity/Portfolio.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/Portfolio.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -168,5 +169,45 @@ public class Portfolio {
      */
     public boolean isDeleted() {
         return this.deletedAt != null;
+    }
+
+    /**
+     * Activate the portfolio (DRAFT -> ACTIVE)
+     */
+    public void activate() {
+        if (this.status != PortfolioStatus.DRAFT) {
+            throw new IllegalStateException("Only DRAFT portfolios can be activated");
+        }
+        this.status = PortfolioStatus.ACTIVE;
+        this.startedAt = LocalDate.now();
+    }
+
+    // ========== Aggregate Root: 하위 엔티티 생성 ==========
+
+    /**
+     * 포트폴리오에 자산 추가 (PortfolioAsset 생성)
+     */
+    public PortfolioAsset addAsset(UUID assetId, BigDecimal weightPct) {
+        if (this.id == null) {
+            throw new IllegalStateException("Portfolio must be persisted before adding assets");
+        }
+        return PortfolioAsset.create(this.id, assetId, weightPct);
+    }
+
+    /**
+     * 포트폴리오 스냅샷 생성
+     */
+    public PortfolioSnapshot createSnapshot(LocalDate effectiveDate, String note) {
+        if (this.id == null) {
+            throw new IllegalStateException("Portfolio must be persisted before creating snapshots");
+        }
+        return PortfolioSnapshot.create(this.id, effectiveDate, note);
+    }
+
+    /**
+     * 포트폴리오 스냅샷 생성 (note 없이)
+     */
+    public PortfolioSnapshot createSnapshot(LocalDate effectiveDate) {
+        return createSnapshot(effectiveDate, null);
     }
 }

--- a/src/main/java/com/porcana/domain/portfolio/entity/PortfolioSnapshot.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/PortfolioSnapshot.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -72,5 +73,17 @@ public class PortfolioSnapshot {
                 .effectiveDate(effectiveDate)
                 .note(note)
                 .build();
+    }
+
+    // ========== Aggregate: 하위 엔티티 생성 ==========
+
+    /**
+     * 스냅샷에 자산 추가 (PortfolioSnapshotAsset 생성)
+     */
+    public PortfolioSnapshotAsset addAsset(UUID assetId, BigDecimal weight) {
+        if (this.id == null) {
+            throw new IllegalStateException("Snapshot must be persisted before adding assets");
+        }
+        return PortfolioSnapshotAsset.create(this.id, assetId, weight);
     }
 }

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -157,8 +157,16 @@ public class PortfolioService {
             BigDecimal equalWeight = BigDecimal.valueOf(100).divide(
                     BigDecimal.valueOf(assets.size()), 2, java.math.RoundingMode.HALF_UP
             );
-            for (DirectCreatePortfolioCommand.AssetWeight asset : assets) {
-                weightMap.put(asset.getAssetId(), equalWeight);
+            BigDecimal totalAssigned = BigDecimal.ZERO;
+            for (int i = 0; i < assets.size(); i++) {
+                DirectCreatePortfolioCommand.AssetWeight asset = assets.get(i);
+                if (i == assets.size() - 1) {
+                    // 마지막 자산은 나머지 비중으로 할당하여 100% 보장
+                    weightMap.put(asset.getAssetId(), BigDecimal.valueOf(100).subtract(totalAssigned));
+                } else {
+                    weightMap.put(asset.getAssetId(), equalWeight);
+                    totalAssigned = totalAssigned.add(equalWeight);
+                }
             }
         }
 

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -3,6 +3,7 @@ package com.porcana.domain.portfolio.service;
 import com.porcana.domain.asset.AssetRepository;
 import com.porcana.domain.asset.entity.Asset;
 import com.porcana.domain.portfolio.command.CreatePortfolioCommand;
+import com.porcana.domain.portfolio.command.DirectCreatePortfolioCommand;
 import com.porcana.domain.portfolio.command.UpdateAssetWeightsCommand;
 import com.porcana.domain.portfolio.command.UpdatePortfolioNameCommand;
 import com.porcana.domain.portfolio.dto.*;
@@ -96,6 +97,93 @@ public class PortfolioService {
         }
 
         Portfolio saved = portfolioRepository.save(portfolio);
+        return CreatePortfolioResponse.from(saved);
+    }
+
+    /**
+     * 직접 종목/비중을 입력하여 포트폴리오 생성 (아레나 방식이 아닌 직접 생성)
+     * - 비중이 null이면 1/n 균등 배분
+     * - 비중이 있으면 합계 100% 검증 후 적용
+     * - 즉시 ACTIVE 상태로 생성
+     */
+    @Transactional
+    public CreatePortfolioResponse createPortfolioDirect(DirectCreatePortfolioCommand command, UUID userId, UUID guestSessionId) {
+        Portfolio portfolio;
+
+        if (userId != null) {
+            portfolio = Portfolio.createForUser(userId, command.getName());
+        } else if (guestSessionId != null) {
+            long guestPortfolioCount = portfolioRepository.countByGuestSessionIdAndDeletedAtIsNull(guestSessionId);
+            if (guestPortfolioCount >= MAX_GUEST_PORTFOLIOS) {
+                throw new IllegalStateException(
+                        String.format("Guest users can create up to %d portfolios. Please sign up to create more.", MAX_GUEST_PORTFOLIOS)
+                );
+            }
+            portfolio = Portfolio.createForGuest(guestSessionId, command.getName());
+        } else {
+            throw new IllegalArgumentException("Either userId or guestSessionId must be provided");
+        }
+
+        // 비중 계산: null이면 1/n 균등 배분
+        List<DirectCreatePortfolioCommand.AssetWeight> assets = command.getAssets();
+        boolean hasAnyWeight = assets.stream().anyMatch(a -> a.getWeightPct() != null);
+
+        Map<UUID, BigDecimal> weightMap = new HashMap<>();
+
+        if (hasAnyWeight) {
+            // 비중이 하나라도 있으면 모두 입력되어야 하고 합계 100% 검증
+            BigDecimal totalWeight = BigDecimal.ZERO;
+            for (DirectCreatePortfolioCommand.AssetWeight asset : assets) {
+                if (asset.getWeightPct() == null) {
+                    throw new IllegalArgumentException("비중을 입력한 경우 모든 종목의 비중을 입력해야 합니다.");
+                }
+                weightMap.put(asset.getAssetId(), asset.getWeightPct());
+                totalWeight = totalWeight.add(asset.getWeightPct());
+            }
+            if (totalWeight.compareTo(BigDecimal.valueOf(100)) != 0) {
+                throw new IllegalArgumentException("비중의 합계는 100%여야 합니다. 현재: " + totalWeight + "%");
+            }
+        } else {
+            // 모두 null이면 1/n 균등 배분
+            BigDecimal equalWeight = BigDecimal.valueOf(100).divide(
+                    BigDecimal.valueOf(assets.size()), 2, java.math.RoundingMode.HALF_UP
+            );
+            for (DirectCreatePortfolioCommand.AssetWeight asset : assets) {
+                weightMap.put(asset.getAssetId(), equalWeight);
+            }
+        }
+
+        // 포트폴리오 저장
+        Portfolio saved = portfolioRepository.save(portfolio);
+
+        // 자산 존재 여부 검증
+        for (DirectCreatePortfolioCommand.AssetWeight asset : assets) {
+            if (!assetRepository.existsById(asset.getAssetId())) {
+                throw new IllegalArgumentException("Asset not found: " + asset.getAssetId());
+            }
+        }
+
+        // 자산 추가 (DDD: Portfolio가 PortfolioAsset 생성)
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        for (DirectCreatePortfolioCommand.AssetWeight asset : assets) {
+            PortfolioAsset portfolioAsset = saved.addAsset(asset.getAssetId(), weightMap.get(asset.getAssetId()));
+            portfolioAssetRepository.save(portfolioAsset);
+        }
+
+        // 스냅샷 생성 (DDD: Portfolio가 PortfolioSnapshot 생성)
+        PortfolioSnapshot snapshot = saved.createSnapshot(today);
+        portfolioSnapshotRepository.save(snapshot);
+
+        // 스냅샷 자산 추가 (DDD: PortfolioSnapshot이 PortfolioSnapshotAsset 생성)
+        for (DirectCreatePortfolioCommand.AssetWeight asset : assets) {
+            PortfolioSnapshotAsset snapshotAsset = snapshot.addAsset(asset.getAssetId(), weightMap.get(asset.getAssetId()));
+            portfolioSnapshotAssetRepository.save(snapshotAsset);
+        }
+
+        // ACTIVE 상태로 변경
+        saved.activate();
+        portfolioRepository.save(saved);
+
         return CreatePortfolioResponse.from(saved);
     }
 

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -135,6 +135,15 @@ public class PortfolioService {
 
         // 비중 계산: null이면 1/n 균등 배분
         List<DirectCreatePortfolioCommand.AssetWeight> assets = command.getAssets();
+
+        // 중복 자산 ID 검증
+        Set<UUID> uniqueAssetIds = assets.stream()
+                .map(DirectCreatePortfolioCommand.AssetWeight::getAssetId)
+                .collect(Collectors.toSet());
+        if (uniqueAssetIds.size() != assets.size()) {
+            throw new IllegalArgumentException("중복된 자산 ID가 존재합니다.");
+        }
+
         boolean hasAnyWeight = assets.stream().anyMatch(a -> a.getWeightPct() != null);
 
         Map<UUID, BigDecimal> weightMap = new HashMap<>();
@@ -170,15 +179,17 @@ public class PortfolioService {
             }
         }
 
+        // 자산 존재 여부 일괄 검증
+        List<UUID> assetIds = assets.stream()
+                .map(DirectCreatePortfolioCommand.AssetWeight::getAssetId)
+                .toList();
+        long existingCount = assetRepository.countByIdIn(assetIds);
+        if (existingCount != assetIds.size()) {
+            throw new IllegalArgumentException("일부 종목을 찾을 수 없습니다.");
+        }
+
         // 포트폴리오 저장
         Portfolio saved = portfolioRepository.save(portfolio);
-
-        // 자산 존재 여부 검증
-        for (DirectCreatePortfolioCommand.AssetWeight asset : assets) {
-            if (!assetRepository.existsById(asset.getAssetId())) {
-                throw new IllegalArgumentException("Asset not found: " + asset.getAssetId());
-            }
-        }
 
         // 자산 추가 (DDD: Portfolio가 PortfolioAsset 생성)
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));

--- a/src/test/java/com/porcana/domain/portfolio/PortfolioControllerTest.java
+++ b/src/test/java/com/porcana/domain/portfolio/PortfolioControllerTest.java
@@ -1,15 +1,18 @@
 package com.porcana.domain.portfolio;
 
 import com.porcana.BaseIntegrationTest;
+import com.porcana.domain.portfolio.dto.DirectCreatePortfolioRequest;
 import com.porcana.domain.portfolio.dto.UpdateAssetWeightsRequest;
 import com.porcana.domain.portfolio.dto.UpdatePortfolioNameRequest;
 import com.porcana.global.security.JwtTokenProvider;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -596,5 +599,270 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 .put("/portfolios/{portfolioId}/weights", TEST_PORTFOLIO_ID)
         .then()
                 .statusCode(400);
+    }
+
+    @Nested
+    @DisplayName("POST /portfolios/direct - 포트폴리오 직접 생성")
+    @Sql(scripts = "/sql/portfolio-direct-create-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    class DirectCreatePortfolioTest {
+
+        private static final UUID DIRECT_TEST_USER_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
+        private static final UUID GUEST_SESSION_ID = UUID.fromString("ccc00000-0000-0000-0000-000000000001");
+
+        private static final UUID ASSET_1 = UUID.fromString("d1111111-1111-1111-1111-111111111111");
+        private static final UUID ASSET_2 = UUID.fromString("d2222222-2222-2222-2222-222222222222");
+        private static final UUID ASSET_3 = UUID.fromString("d3333333-3333-3333-3333-333333333333");
+        private static final UUID ASSET_4 = UUID.fromString("d4444444-4444-4444-4444-444444444444");
+        private static final UUID ASSET_5 = UUID.fromString("d5555555-5555-5555-5555-555555555555");
+        private static final UUID ASSET_6 = UUID.fromString("d6666666-6666-6666-6666-666666666666");
+        private static final UUID ASSET_7 = UUID.fromString("d7777777-7777-7777-7777-777777777777");
+
+        private String createAccessToken() {
+            return jwtTokenProvider.createAccessToken(DIRECT_TEST_USER_ID);
+        }
+
+        @Test
+        @DisplayName("성공 - 비중 직접 입력 (5종목)")
+        void createPortfolioDirect_success_withWeights() {
+            String accessToken = createAccessToken();
+
+            DirectCreatePortfolioRequest request = new DirectCreatePortfolioRequest(
+                    "직접 생성 포트폴리오",
+                    List.of(
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_1, BigDecimal.valueOf(30)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_2, BigDecimal.valueOf(25)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_3, BigDecimal.valueOf(20)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_4, BigDecimal.valueOf(15)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_5, BigDecimal.valueOf(10))
+                    )
+            );
+
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .post("/portfolios/direct")
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("portfolioId", notNullValue())
+                    .body("name", equalTo("직접 생성 포트폴리오"))
+                    .body("status", equalTo("ACTIVE"));
+        }
+
+        @Test
+        @DisplayName("성공 - 균등 배분 (비중 생략)")
+        void createPortfolioDirect_success_equalWeight() {
+            String accessToken = createAccessToken();
+
+            DirectCreatePortfolioRequest request = new DirectCreatePortfolioRequest(
+                    "균등 배분 포트폴리오",
+                    List.of(
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_1, null),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_2, null),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_3, null),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_4, null),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_5, null)
+                    )
+            );
+
+            String portfolioId = given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .post("/portfolios/direct")
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("portfolioId", notNullValue())
+                    .body("status", equalTo("ACTIVE"))
+                    .extract().path("portfolioId");
+
+            // 포트폴리오 상세 조회해서 균등 배분 확인 (각 20%)
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+            .when()
+                    .get("/portfolios/{portfolioId}", portfolioId)
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("positions", hasSize(5))
+                    .body("positions.weightPct", everyItem(equalTo(20.0f)));
+        }
+
+        @Test
+        @DisplayName("성공 - 게스트 사용자")
+        void createPortfolioDirect_success_guest() {
+            DirectCreatePortfolioRequest request = new DirectCreatePortfolioRequest(
+                    "게스트 포트폴리오",
+                    List.of(
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_1, BigDecimal.valueOf(20)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_2, BigDecimal.valueOf(20)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_3, BigDecimal.valueOf(20)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_4, BigDecimal.valueOf(20)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_5, BigDecimal.valueOf(20))
+                    )
+            );
+
+            given()
+                    .header("X-Guest-Session-Id", GUEST_SESSION_ID.toString())
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .post("/portfolios/direct")
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("portfolioId", notNullValue())
+                    .body("status", equalTo("ACTIVE"));
+        }
+
+        @Test
+        @DisplayName("실패 - 종목 개수 부족 (4개)")
+        void createPortfolioDirect_fail_tooFewAssets() {
+            String accessToken = createAccessToken();
+
+            DirectCreatePortfolioRequest request = new DirectCreatePortfolioRequest(
+                    "종목 부족",
+                    List.of(
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_1, BigDecimal.valueOf(25)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_2, BigDecimal.valueOf(25)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_3, BigDecimal.valueOf(25)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_4, BigDecimal.valueOf(25))
+                    )
+            );
+
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .post("/portfolios/direct")
+            .then()
+                    .log().all()
+                    .statusCode(400);
+        }
+
+        @Test
+        @DisplayName("실패 - 비중 합계가 100%가 아님")
+        void createPortfolioDirect_fail_weightNot100() {
+            String accessToken = createAccessToken();
+
+            DirectCreatePortfolioRequest request = new DirectCreatePortfolioRequest(
+                    "비중 오류",
+                    List.of(
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_1, BigDecimal.valueOf(30)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_2, BigDecimal.valueOf(30)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_3, BigDecimal.valueOf(20)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_4, BigDecimal.valueOf(10)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_5, BigDecimal.valueOf(5))
+                    )
+            );
+
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .post("/portfolios/direct")
+            .then()
+                    .log().all()
+                    .statusCode(400);
+        }
+
+        @Test
+        @DisplayName("실패 - 비중 일부만 입력")
+        void createPortfolioDirect_fail_partialWeights() {
+            String accessToken = createAccessToken();
+
+            DirectCreatePortfolioRequest request = new DirectCreatePortfolioRequest(
+                    "일부 비중만",
+                    List.of(
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_1, BigDecimal.valueOf(50)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_2, null),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_3, BigDecimal.valueOf(30)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_4, null),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_5, BigDecimal.valueOf(20))
+                    )
+            );
+
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .post("/portfolios/direct")
+            .then()
+                    .log().all()
+                    .statusCode(400);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 종목")
+        void createPortfolioDirect_fail_assetNotFound() {
+            String accessToken = createAccessToken();
+            UUID nonExistentAsset = UUID.randomUUID();
+
+            DirectCreatePortfolioRequest request = new DirectCreatePortfolioRequest(
+                    "존재하지 않는 종목",
+                    List.of(
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_1, BigDecimal.valueOf(20)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_2, BigDecimal.valueOf(20)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_3, BigDecimal.valueOf(20)),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_4, BigDecimal.valueOf(20)),
+                            new DirectCreatePortfolioRequest.AssetInput(nonExistentAsset, BigDecimal.valueOf(20))
+                    )
+            );
+
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .post("/portfolios/direct")
+            .then()
+                    .log().all()
+                    .statusCode(400);
+        }
+
+        @Test
+        @DisplayName("성공 - 생성 후 포트폴리오 목록에서 조회됨")
+        void createPortfolioDirect_appearsInList() {
+            String accessToken = createAccessToken();
+
+            DirectCreatePortfolioRequest request = new DirectCreatePortfolioRequest(
+                    "목록 확인용",
+                    List.of(
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_1, null),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_2, null),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_3, null),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_4, null),
+                            new DirectCreatePortfolioRequest.AssetInput(ASSET_5, null)
+                    )
+            );
+
+            String portfolioId = given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .post("/portfolios/direct")
+            .then()
+                    .statusCode(200)
+                    .extract().path("portfolioId");
+
+            // 목록에서 조회
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+            .when()
+                    .get("/portfolios")
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("find { it.portfolioId == '" + portfolioId + "' }", notNullValue())
+                    .body("find { it.portfolioId == '" + portfolioId + "' }.status", equalTo("ACTIVE"));
+        }
     }
 }

--- a/src/test/resources/sql/portfolio-direct-create-test-data.sql
+++ b/src/test/resources/sql/portfolio-direct-create-test-data.sql
@@ -1,0 +1,36 @@
+-- Test data for Portfolio Direct Create API Test
+-- Clean up existing data
+DELETE FROM portfolio_snapshot_assets WHERE snapshot_id IN (
+    SELECT id FROM portfolio_snapshots WHERE portfolio_id IN (
+        SELECT id FROM portfolios WHERE user_id = '550e8400-e29b-41d4-a716-446655440001'
+    )
+);
+DELETE FROM portfolio_snapshots WHERE portfolio_id IN (
+    SELECT id FROM portfolios WHERE user_id = '550e8400-e29b-41d4-a716-446655440001'
+);
+DELETE FROM portfolio_assets WHERE portfolio_id IN (
+    SELECT id FROM portfolios WHERE user_id = '550e8400-e29b-41d4-a716-446655440001'
+);
+DELETE FROM portfolios WHERE user_id = '550e8400-e29b-41d4-a716-446655440001';
+DELETE FROM assets WHERE symbol LIKE 'DIRECT_TEST_%';
+DELETE FROM users WHERE email = 'direct-create-test@example.com';
+DELETE FROM guest_sessions WHERE id = 'ccc00000-0000-0000-0000-000000000001';
+
+-- Insert test user
+INSERT INTO users (id, email, password, nickname, provider, main_portfolio_id, created_at, updated_at)
+VALUES ('550e8400-e29b-41d4-a716-446655440001', 'direct-create-test@example.com', 'password123', '직접생성테스터', 'EMAIL', NULL, NOW(), NOW());
+
+-- Insert guest session
+INSERT INTO guest_sessions (id, last_seen_at, created_at)
+VALUES ('ccc00000-0000-0000-0000-000000000001', NOW(), NOW());
+
+-- Insert test assets (7 assets for testing min 5, max 20)
+INSERT INTO assets (id, symbol, name, market, type, sector, current_risk_level, active, image_url, created_at, updated_at, as_of)
+VALUES
+    ('d1111111-1111-1111-1111-111111111111', 'DIRECT_TEST_1', '테스트종목1', 'KR', 'STOCK', 'INFORMATION_TECHNOLOGY', 3, true, NULL, NOW(), NOW(), NOW()),
+    ('d2222222-2222-2222-2222-222222222222', 'DIRECT_TEST_2', '테스트종목2', 'KR', 'STOCK', 'HEALTH_CARE', 4, true, NULL, NOW(), NOW(), NOW()),
+    ('d3333333-3333-3333-3333-333333333333', 'DIRECT_TEST_3', '테스트종목3', 'US', 'STOCK', 'FINANCIALS', 2, true, NULL, NOW(), NOW(), NOW()),
+    ('d4444444-4444-4444-4444-444444444444', 'DIRECT_TEST_4', '테스트종목4', 'US', 'STOCK', 'CONSUMER_DISCRETIONARY', 5, true, NULL, NOW(), NOW(), NOW()),
+    ('d5555555-5555-5555-5555-555555555555', 'DIRECT_TEST_5', '테스트종목5', 'KR', 'ETF', NULL, 1, true, NULL, NOW(), NOW(), NOW()),
+    ('d6666666-6666-6666-6666-666666666666', 'DIRECT_TEST_6', '테스트종목6', 'US', 'ETF', NULL, 2, true, NULL, NOW(), NOW(), NOW()),
+    ('d7777777-7777-7777-7777-777777777777', 'DIRECT_TEST_7', '테스트종목7', 'KR', 'STOCK', 'INDUSTRIALS', 3, true, NULL, NOW(), NOW(), NOW());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 자산과 가중치를 직접 지정해 포트폴리오 생성 가능 (POST /portfolios/direct)
  * 가중치 명시 또는 생략 시 균등 분배 지원(모두 생략 시 1/n)
  * 가중치 지정 시 합계 100% 자동 검증, 합계 불일치 시 400 반환
  * 5~20개 자산 허용, 중복 자산 및 존재하지 않는 자산은 거부
  * 생성 즉시 ACTIVE 상태로 활성화되며 게스트는 최대 3개 포트폴리오 생성 제한, 소유권 검사로 403 반환
<!-- end of auto-generated comment: release notes by coderabbit.ai -->