### PR TITLE
Feat: 배당 데이터 도메인 및 자산 성격 분석 시스템

### DIFF
--- a/src/main/java/com/porcana/batch/provider/us/FmpAssetProvider.java
+++ b/src/main/java/com/porcana/batch/provider/us/FmpAssetProvider.java
@@ -14,14 +14,20 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import com.porcana.domain.asset.entity.DividendCategory;
+import com.porcana.domain.asset.entity.DividendDataStatus;
+import com.porcana.domain.asset.entity.DividendFrequency;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,8 +42,12 @@ public class FmpAssetProvider implements UsAssetDataProvider {
 
     private static final String PROFILE_ENDPOINT = "/stable/profile";
     private static final String HISTORICAL_PRICE_ENDPOINT = "/stable/historical-price-eod/full";
+    private static final String HISTORICAL_DIVIDENDS_ENDPOINT = "/api/v3/historical-price-full/stock_dividend";
     private static final String SP500_CSV = "batch/s&p500.csv";
     private static final String NASDAQ100_CSV = "batch/nasdaq100.csv";
+
+    // 배당 수익률 임계값 (소수 기준)
+    private static final BigDecimal HIGH_DIVIDEND_THRESHOLD = new BigDecimal("0.04");  // 4% 이상 = 고배당
 
     private final RestTemplate restTemplate;
     private final String apiKey;
@@ -372,6 +382,254 @@ public class FmpAssetProvider implements UsAssetDataProvider {
     @Override
     public String getProviderName() {
         return "FMP";
+    }
+
+    /**
+     * Fetch dividend data for a single symbol from FMP API
+     *
+     * @param symbol The stock symbol
+     * @return DividendData containing yield, frequency, category, etc.
+     */
+    public DividendData fetchDividendData(String symbol) {
+        if (apiKey == null || apiKey.isBlank()) {
+            log.warn("FMP API key not configured. Skipping dividend fetch.");
+            return null;
+        }
+
+        try {
+            // 1. Fetch profile for lastDiv and price
+            FmpProfile profile = fetchProfile(symbol);
+            if (profile == null) {
+                log.debug("No profile data for symbol: {}", symbol);
+                return null;
+            }
+
+            // 2. Fetch historical dividends for frequency analysis
+            List<FmpDividend> dividends = fetchHistoricalDividends(symbol);
+
+            // 3. Calculate dividend data
+            return calculateDividendData(symbol, profile, dividends);
+
+        } catch (Exception e) {
+            log.warn("Failed to fetch dividend data for symbol: {}. Error: {}", symbol, e.getMessage());
+            return null;
+        }
+    }
+
+    private FmpProfile fetchProfile(String symbol) {
+        String url = String.format("%s%s?symbol=%s&apikey=%s", baseUrl, PROFILE_ENDPOINT, symbol, apiKey);
+
+        try {
+            FmpProfile[] profiles = restTemplate.getForObject(url, FmpProfile[].class);
+            if (profiles == null || profiles.length == 0) {
+                return null;
+            }
+            return profiles[0];
+        } catch (Exception e) {
+            log.debug("Failed to fetch profile for {}: {}", symbol, e.getMessage());
+            return null;
+        }
+    }
+
+    private List<FmpDividend> fetchHistoricalDividends(String symbol) {
+        // FMP Historical Dividends API
+        String url = String.format("%s/%s/%s?apikey=%s", baseUrl, HISTORICAL_DIVIDENDS_ENDPOINT, symbol, apiKey);
+
+        try {
+            FmpDividendResponse response = restTemplate.getForObject(url, FmpDividendResponse.class);
+            if (response == null || response.getHistorical() == null) {
+                return new ArrayList<>();
+            }
+            return response.getHistorical();
+        } catch (Exception e) {
+            log.debug("Failed to fetch historical dividends for {}: {}", symbol, e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    private DividendData calculateDividendData(String symbol, FmpProfile profile, List<FmpDividend> dividends) {
+        // Check if dividend available
+        boolean hasDividend = profile.getLastDiv() != null && profile.getLastDiv() > 0;
+
+        if (!hasDividend && dividends.isEmpty()) {
+            return DividendData.builder()
+                    .dividendAvailable(false)
+                    .dividendYield(null)
+                    .dividendFrequency(DividendFrequency.NONE)
+                    .dividendCategory(DividendCategory.NONE)
+                    .dividendDataStatus(DividendDataStatus.VERIFIED)
+                    .lastDividendDate(null)
+                    .build();
+        }
+
+        // Calculate dividend yield from lastDiv and price
+        BigDecimal dividendYield = null;
+        if (profile.getLastDiv() != null && profile.getPrice() != null && profile.getPrice() > 0) {
+            // lastDiv is per-share dividend, need to annualize based on frequency
+            // For now, assume lastDiv is already annualized (FMP typically provides TTM dividend)
+            double yield = profile.getLastDiv() / profile.getPrice();
+            dividendYield = BigDecimal.valueOf(yield).setScale(6, RoundingMode.HALF_UP);
+        }
+
+        // Determine frequency from historical dividends
+        DividendFrequency frequency = determineDividendFrequency(dividends);
+
+        // Determine category based on yield
+        DividendCategory category = determineDividendCategory(dividendYield, profile);
+
+        // Get last dividend date
+        LocalDate lastDividendDate = null;
+        if (!dividends.isEmpty()) {
+            dividends.sort(Comparator.comparing(FmpDividend::getPaymentDate, Comparator.nullsLast(Comparator.reverseOrder())));
+            FmpDividend lastDividend = dividends.get(0);
+            if (lastDividend.getPaymentDate() != null) {
+                try {
+                    lastDividendDate = LocalDate.parse(lastDividend.getPaymentDate());
+                } catch (Exception e) {
+                    log.debug("Failed to parse dividend date for {}: {}", symbol, lastDividend.getPaymentDate());
+                }
+            }
+        }
+
+        return DividendData.builder()
+                .dividendAvailable(true)
+                .dividendYield(dividendYield)
+                .dividendFrequency(frequency)
+                .dividendCategory(category)
+                .dividendDataStatus(DividendDataStatus.VERIFIED)
+                .lastDividendDate(lastDividendDate)
+                .build();
+    }
+
+    private DividendFrequency determineDividendFrequency(List<FmpDividend> dividends) {
+        if (dividends.isEmpty()) {
+            return DividendFrequency.UNKNOWN;
+        }
+
+        // Filter last 2 years of dividends
+        LocalDate twoYearsAgo = LocalDate.now().minusYears(2);
+        List<FmpDividend> recentDividends = dividends.stream()
+                .filter(d -> {
+                    if (d.getPaymentDate() == null) return false;
+                    try {
+                        LocalDate date = LocalDate.parse(d.getPaymentDate());
+                        return date.isAfter(twoYearsAgo);
+                    } catch (Exception e) {
+                        return false;
+                    }
+                })
+                .sorted(Comparator.comparing(d -> LocalDate.parse(d.getPaymentDate())))
+                .toList();
+
+        if (recentDividends.size() < 2) {
+            return DividendFrequency.UNKNOWN;
+        }
+
+        // Calculate average days between dividends
+        long totalDays = 0;
+        int intervals = 0;
+        for (int i = 1; i < recentDividends.size(); i++) {
+            LocalDate prevDate = LocalDate.parse(recentDividends.get(i - 1).getPaymentDate());
+            LocalDate currDate = LocalDate.parse(recentDividends.get(i).getPaymentDate());
+            totalDays += ChronoUnit.DAYS.between(prevDate, currDate);
+            intervals++;
+        }
+
+        if (intervals == 0) {
+            return DividendFrequency.UNKNOWN;
+        }
+
+        long avgDays = totalDays / intervals;
+
+        // Determine frequency based on average interval
+        if (avgDays <= 45) {          // ~30 days = monthly
+            return DividendFrequency.MONTHLY;
+        } else if (avgDays <= 120) {  // ~90 days = quarterly
+            return DividendFrequency.QUARTERLY;
+        } else if (avgDays <= 210) {  // ~180 days = semi-annual
+            return DividendFrequency.SEMI_ANNUAL;
+        } else if (avgDays <= 400) {  // ~365 days = annual
+            return DividendFrequency.ANNUAL;
+        } else {
+            return DividendFrequency.IRREGULAR;
+        }
+    }
+
+    private DividendCategory determineDividendCategory(BigDecimal dividendYield, FmpProfile profile) {
+        if (dividendYield == null || dividendYield.compareTo(BigDecimal.ZERO) <= 0) {
+            return DividendCategory.NONE;
+        }
+
+        // Check for REIT (Real Estate Investment Trust)
+        if (profile.getSector() != null &&
+                (profile.getSector().toLowerCase().contains("real estate") ||
+                 profile.getIndustry() != null && profile.getIndustry().toLowerCase().contains("reit"))) {
+            return DividendCategory.REIT_LIKE;
+        }
+
+        // Categorize by yield
+        if (dividendYield.compareTo(HIGH_DIVIDEND_THRESHOLD) >= 0) {
+            return DividendCategory.HIGH_DIVIDEND;
+        } else if (dividendYield.compareTo(new BigDecimal("0.02")) >= 0) {
+            return DividendCategory.DIVIDEND_GROWTH;
+        } else {
+            return DividendCategory.HAS_DIVIDEND;
+        }
+    }
+
+    /**
+     * Dividend data result
+     */
+    @Data
+    @lombok.Builder
+    public static class DividendData {
+        private Boolean dividendAvailable;
+        private BigDecimal dividendYield;
+        private DividendFrequency dividendFrequency;
+        private DividendCategory dividendCategory;
+        private DividendDataStatus dividendDataStatus;
+        private LocalDate lastDividendDate;
+    }
+
+    /**
+     * FMP Historical Dividends Response
+     */
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class FmpDividendResponse {
+        @JsonProperty("symbol")
+        private String symbol;
+
+        @JsonProperty("historical")
+        private List<FmpDividend> historical;
+    }
+
+    /**
+     * FMP Dividend Entry
+     */
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class FmpDividend {
+        @JsonProperty("date")
+        private String date;
+
+        @JsonProperty("label")
+        private String label;
+
+        @JsonProperty("adjDividend")
+        private Double adjDividend;
+
+        @JsonProperty("dividend")
+        private Double dividend;
+
+        @JsonProperty("recordDate")
+        private String recordDate;
+
+        @JsonProperty("paymentDate")
+        private String paymentDate;
+
+        @JsonProperty("declarationDate")
+        private String declarationDate;
     }
 
     /**

--- a/src/main/java/com/porcana/batch/provider/us/FmpAssetProvider.java
+++ b/src/main/java/com/porcana/batch/provider/us/FmpAssetProvider.java
@@ -25,9 +25,7 @@ import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -42,7 +40,8 @@ public class FmpAssetProvider implements UsAssetDataProvider {
 
     private static final String PROFILE_ENDPOINT = "/stable/profile";
     private static final String HISTORICAL_PRICE_ENDPOINT = "/stable/historical-price-eod/full";
-    private static final String HISTORICAL_DIVIDENDS_ENDPOINT = "/api/v3/historical-price-full/stock_dividend";
+    private static final String DIVIDENDS_ENDPOINT = "/stable/dividends";
+    private static final String RATIOS_TTM_ENDPOINT = "/stable/ratios-ttm";
     private static final String SP500_CSV = "batch/s&p500.csv";
     private static final String NASDAQ100_CSV = "batch/nasdaq100.csv";
 
@@ -385,7 +384,7 @@ public class FmpAssetProvider implements UsAssetDataProvider {
     }
 
     /**
-     * Fetch dividend data for a single symbol from FMP API
+     * Fetch dividend data for a single symbol from FMP API (stable endpoints)
      *
      * @param symbol The stock symbol
      * @return DividendData containing yield, frequency, category, etc.
@@ -397,18 +396,17 @@ public class FmpAssetProvider implements UsAssetDataProvider {
         }
 
         try {
-            // 1. Fetch profile for lastDiv and price
+            // 1. Fetch dividend history from /stable/dividends
+            List<FmpDividend> dividends = fetchDividends(symbol);
+
+            // 2. Fetch ratios for TTM yield
+            FmpRatiosTtm ratios = fetchRatiosTtm(symbol);
+
+            // 3. Fetch profile for sector/industry info
             FmpProfile profile = fetchProfile(symbol);
-            if (profile == null) {
-                log.debug("No profile data for symbol: {}", symbol);
-                return null;
-            }
 
-            // 2. Fetch historical dividends for frequency analysis
-            List<FmpDividend> dividends = fetchHistoricalDividends(symbol);
-
-            // 3. Calculate dividend data
-            return calculateDividendData(symbol, profile, dividends);
+            // 4. Calculate dividend data
+            return calculateDividendData(symbol, dividends, ratios, profile);
 
         } catch (Exception e) {
             log.warn("Failed to fetch dividend data for symbol: {}. Error: {}", symbol, e.getMessage());
@@ -431,27 +429,45 @@ public class FmpAssetProvider implements UsAssetDataProvider {
         }
     }
 
-    private List<FmpDividend> fetchHistoricalDividends(String symbol) {
-        // FMP Historical Dividends API
-        String url = String.format("%s/%s/%s?apikey=%s", baseUrl, HISTORICAL_DIVIDENDS_ENDPOINT, symbol, apiKey);
+    private List<FmpDividend> fetchDividends(String symbol) {
+        // FMP Stable Dividends API: /stable/dividends?symbol=AAPL
+        String url = String.format("%s%s?symbol=%s&apikey=%s", baseUrl, DIVIDENDS_ENDPOINT, symbol, apiKey);
 
         try {
-            FmpDividendResponse response = restTemplate.getForObject(url, FmpDividendResponse.class);
-            if (response == null || response.getHistorical() == null) {
+            FmpDividend[] dividends = restTemplate.getForObject(url, FmpDividend[].class);
+            if (dividends == null) {
                 return new ArrayList<>();
             }
-            return response.getHistorical();
+            return new ArrayList<>(List.of(dividends));
         } catch (Exception e) {
-            log.debug("Failed to fetch historical dividends for {}: {}", symbol, e.getMessage());
+            log.debug("Failed to fetch dividends for {}: {}", symbol, e.getMessage());
             return new ArrayList<>();
         }
     }
 
-    private DividendData calculateDividendData(String symbol, FmpProfile profile, List<FmpDividend> dividends) {
-        // Check if dividend available
-        boolean hasDividend = profile.getLastDiv() != null && profile.getLastDiv() > 0;
+    private FmpRatiosTtm fetchRatiosTtm(String symbol) {
+        // FMP Stable Ratios TTM API: /stable/ratios-ttm?symbol=AAPL
+        String url = String.format("%s%s?symbol=%s&apikey=%s", baseUrl, RATIOS_TTM_ENDPOINT, symbol, apiKey);
 
-        if (!hasDividend && dividends.isEmpty()) {
+        try {
+            FmpRatiosTtm[] ratios = restTemplate.getForObject(url, FmpRatiosTtm[].class);
+            if (ratios == null || ratios.length == 0) {
+                return null;
+            }
+            return ratios[0];
+        } catch (Exception e) {
+            log.debug("Failed to fetch ratios-ttm for {}: {}", symbol, e.getMessage());
+            return null;
+        }
+    }
+
+    private DividendData calculateDividendData(String symbol, List<FmpDividend> dividends,
+                                                FmpRatiosTtm ratios, FmpProfile profile) {
+        // Check if dividend available
+        boolean hasDividend = !dividends.isEmpty() ||
+                (ratios != null && ratios.getDividendYieldTTM() != null && ratios.getDividendYieldTTM() > 0);
+
+        if (!hasDividend) {
             return DividendData.builder()
                     .dividendAvailable(false)
                     .dividendYield(null)
@@ -462,16 +478,13 @@ public class FmpAssetProvider implements UsAssetDataProvider {
                     .build();
         }
 
-        // Calculate dividend yield from lastDiv and price
+        // Get dividend yield from ratios-ttm (most accurate)
         BigDecimal dividendYield = null;
-        if (profile.getLastDiv() != null && profile.getPrice() != null && profile.getPrice() > 0) {
-            // lastDiv is per-share dividend, need to annualize based on frequency
-            // For now, assume lastDiv is already annualized (FMP typically provides TTM dividend)
-            double yield = profile.getLastDiv() / profile.getPrice();
-            dividendYield = BigDecimal.valueOf(yield).setScale(6, RoundingMode.HALF_UP);
+        if (ratios != null && ratios.getDividendYieldTTM() != null) {
+            dividendYield = BigDecimal.valueOf(ratios.getDividendYieldTTM()).setScale(6, RoundingMode.HALF_UP);
         }
 
-        // Determine frequency from historical dividends
+        // Determine frequency from dividend data (FMP provides it directly)
         DividendFrequency frequency = determineDividendFrequency(dividends);
 
         // Determine category based on yield
@@ -480,7 +493,7 @@ public class FmpAssetProvider implements UsAssetDataProvider {
         // Get last dividend date
         LocalDate lastDividendDate = null;
         if (!dividends.isEmpty()) {
-            dividends.sort(Comparator.comparing(FmpDividend::getPaymentDate, Comparator.nullsLast(Comparator.reverseOrder())));
+            // Dividends are already sorted by date desc from API
             FmpDividend lastDividend = dividends.get(0);
             if (lastDividend.getPaymentDate() != null) {
                 try {
@@ -506,53 +519,19 @@ public class FmpAssetProvider implements UsAssetDataProvider {
             return DividendFrequency.UNKNOWN;
         }
 
-        // Filter last 2 years of dividends
-        LocalDate twoYearsAgo = LocalDate.now().minusYears(2);
-        List<FmpDividend> recentDividends = dividends.stream()
-                .filter(d -> {
-                    if (d.getPaymentDate() == null) return false;
-                    try {
-                        LocalDate date = LocalDate.parse(d.getPaymentDate());
-                        return date.isAfter(twoYearsAgo);
-                    } catch (Exception e) {
-                        return false;
-                    }
-                })
-                .sorted(Comparator.comparing(d -> LocalDate.parse(d.getPaymentDate())))
-                .toList();
-
-        if (recentDividends.size() < 2) {
-            return DividendFrequency.UNKNOWN;
+        // FMP provides frequency directly in dividend data
+        FmpDividend firstDividend = dividends.get(0);
+        if (firstDividend.getFrequency() != null) {
+            return switch (firstDividend.getFrequency().toLowerCase()) {
+                case "monthly" -> DividendFrequency.MONTHLY;
+                case "quarterly" -> DividendFrequency.QUARTERLY;
+                case "semi-annual", "semi-annually" -> DividendFrequency.SEMI_ANNUAL;
+                case "annual", "annually" -> DividendFrequency.ANNUAL;
+                default -> DividendFrequency.IRREGULAR;
+            };
         }
 
-        // Calculate average days between dividends
-        long totalDays = 0;
-        int intervals = 0;
-        for (int i = 1; i < recentDividends.size(); i++) {
-            LocalDate prevDate = LocalDate.parse(recentDividends.get(i - 1).getPaymentDate());
-            LocalDate currDate = LocalDate.parse(recentDividends.get(i).getPaymentDate());
-            totalDays += ChronoUnit.DAYS.between(prevDate, currDate);
-            intervals++;
-        }
-
-        if (intervals == 0) {
-            return DividendFrequency.UNKNOWN;
-        }
-
-        long avgDays = totalDays / intervals;
-
-        // Determine frequency based on average interval
-        if (avgDays <= 45) {          // ~30 days = monthly
-            return DividendFrequency.MONTHLY;
-        } else if (avgDays <= 120) {  // ~90 days = quarterly
-            return DividendFrequency.QUARTERLY;
-        } else if (avgDays <= 210) {  // ~180 days = semi-annual
-            return DividendFrequency.SEMI_ANNUAL;
-        } else if (avgDays <= 400) {  // ~365 days = annual
-            return DividendFrequency.ANNUAL;
-        } else {
-            return DividendFrequency.IRREGULAR;
-        }
+        return DividendFrequency.UNKNOWN;
     }
 
     private DividendCategory determineDividendCategory(BigDecimal dividendYield, FmpProfile profile) {
@@ -561,9 +540,9 @@ public class FmpAssetProvider implements UsAssetDataProvider {
         }
 
         // Check for REIT (Real Estate Investment Trust)
-        if (profile.getSector() != null &&
+        if (profile != null && profile.getSector() != null &&
                 (profile.getSector().toLowerCase().contains("real estate") ||
-                 profile.getIndustry() != null && profile.getIndustry().toLowerCase().contains("reit"))) {
+                 (profile.getIndustry() != null && profile.getIndustry().toLowerCase().contains("reit")))) {
             return DividendCategory.REIT_LIKE;
         }
 
@@ -592,35 +571,16 @@ public class FmpAssetProvider implements UsAssetDataProvider {
     }
 
     /**
-     * FMP Historical Dividends Response
-     */
-    @Data
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class FmpDividendResponse {
-        @JsonProperty("symbol")
-        private String symbol;
-
-        @JsonProperty("historical")
-        private List<FmpDividend> historical;
-    }
-
-    /**
-     * FMP Dividend Entry
+     * FMP Dividend Entry (from /stable/dividends)
      */
     @Data
     @JsonIgnoreProperties(ignoreUnknown = true)
     private static class FmpDividend {
+        @JsonProperty("symbol")
+        private String symbol;
+
         @JsonProperty("date")
         private String date;
-
-        @JsonProperty("label")
-        private String label;
-
-        @JsonProperty("adjDividend")
-        private Double adjDividend;
-
-        @JsonProperty("dividend")
-        private Double dividend;
 
         @JsonProperty("recordDate")
         private String recordDate;
@@ -630,6 +590,37 @@ public class FmpAssetProvider implements UsAssetDataProvider {
 
         @JsonProperty("declarationDate")
         private String declarationDate;
+
+        @JsonProperty("adjDividend")
+        private Double adjDividend;
+
+        @JsonProperty("dividend")
+        private Double dividend;
+
+        @JsonProperty("yield")
+        private Double yield;
+
+        @JsonProperty("frequency")
+        private String frequency;
+    }
+
+    /**
+     * FMP Ratios TTM (from /stable/ratios-ttm)
+     */
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class FmpRatiosTtm {
+        @JsonProperty("symbol")
+        private String symbol;
+
+        @JsonProperty("dividendYieldTTM")
+        private Double dividendYieldTTM;
+
+        @JsonProperty("dividendPerShareTTM")
+        private Double dividendPerShareTTM;
+
+        @JsonProperty("dividendPayoutRatioTTM")
+        private Double dividendPayoutRatioTTM;
     }
 
     /**

--- a/src/main/java/com/porcana/batch/runner/DividendDataUpdateRunner.java
+++ b/src/main/java/com/porcana/batch/runner/DividendDataUpdateRunner.java
@@ -3,8 +3,8 @@ package com.porcana.batch.runner;
 import com.porcana.batch.provider.us.FmpAssetProvider;
 import com.porcana.domain.asset.AssetRepository;
 import com.porcana.domain.asset.entity.Asset;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
@@ -15,24 +15,31 @@ import java.util.List;
 /**
  * ApplicationRunner for updating dividend data from FMP API
  *
- * Usage: Run the application with DIVIDEND_UPDATE_ENABLED=true environment variable
- * To disable: Comment out @Component annotation or don't set the env variable
+ * Usage: Set DIVIDEND_UPDATE_ENABLED=true in application.yml or as environment variable
  *
  * Example:
  *   DIVIDEND_UPDATE_ENABLED=true ./gradlew bootRun
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class DividendDataUpdateRunner implements ApplicationRunner {
 
     private final AssetRepository assetRepository;
     private final FmpAssetProvider fmpAssetProvider;
+    private final boolean enabled;
+
+    public DividendDataUpdateRunner(
+            AssetRepository assetRepository,
+            FmpAssetProvider fmpAssetProvider,
+            @Value("${DIVIDEND_UPDATE_ENABLED:false}") boolean enabled) {
+        this.assetRepository = assetRepository;
+        this.fmpAssetProvider = fmpAssetProvider;
+        this.enabled = enabled;
+    }
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
-        String enabled = System.getenv("DIVIDEND_UPDATE_ENABLED");
-        if (!"true".equalsIgnoreCase(enabled)) {
+        if (!enabled) {
             log.info("Dividend data update is disabled. Set DIVIDEND_UPDATE_ENABLED=true to enable.");
             return;
         }

--- a/src/main/java/com/porcana/batch/runner/DividendDataUpdateRunner.java
+++ b/src/main/java/com/porcana/batch/runner/DividendDataUpdateRunner.java
@@ -1,0 +1,118 @@
+package com.porcana.batch.runner;
+
+import com.porcana.batch.provider.us.FmpAssetProvider;
+import com.porcana.domain.asset.AssetRepository;
+import com.porcana.domain.asset.entity.Asset;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * ApplicationRunner for updating dividend data from FMP API
+ *
+ * Usage: Run the application with DIVIDEND_UPDATE_ENABLED=true environment variable
+ * To disable: Comment out @Component annotation or don't set the env variable
+ *
+ * Example:
+ *   DIVIDEND_UPDATE_ENABLED=true ./gradlew bootRun
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DividendDataUpdateRunner implements ApplicationRunner {
+
+    private final AssetRepository assetRepository;
+    private final FmpAssetProvider fmpAssetProvider;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        String enabled = System.getenv("DIVIDEND_UPDATE_ENABLED");
+        if (!"true".equalsIgnoreCase(enabled)) {
+            log.info("Dividend data update is disabled. Set DIVIDEND_UPDATE_ENABLED=true to enable.");
+            return;
+        }
+
+        log.info("Starting Dividend Data Update Runner");
+
+        try {
+            updateDividendData();
+            log.info("Dividend Data Update Runner completed successfully");
+        } catch (Exception e) {
+            log.error("Dividend Data Update Runner failed", e);
+            throw e;
+        }
+    }
+
+    @Transactional
+    public void updateDividendData() {
+        // Fetch all active US market assets
+        List<Asset> usAssets = assetRepository.findByMarketAndActiveTrue(Asset.Market.US);
+        log.info("Found {} active US market assets to update dividend data", usAssets.size());
+
+        int total = usAssets.size();
+        int updated = 0;
+        int failed = 0;
+        int skipped = 0;
+
+        for (int i = 0; i < usAssets.size(); i++) {
+            Asset asset = usAssets.get(i);
+            String symbol = asset.getSymbol();
+
+            try {
+                log.info("Processing {}/{}: {}", i + 1, total, symbol);
+
+                FmpAssetProvider.DividendData dividendData = fmpAssetProvider.fetchDividendData(symbol);
+
+                if (dividendData == null) {
+                    log.warn("No dividend data returned for: {}", symbol);
+                    skipped++;
+                    continue;
+                }
+
+                // Update asset with dividend data
+                asset.updateDividendData(
+                        dividendData.getDividendAvailable(),
+                        dividendData.getDividendYield(),
+                        dividendData.getDividendFrequency(),
+                        dividendData.getDividendCategory(),
+                        dividendData.getDividendDataStatus(),
+                        dividendData.getLastDividendDate()
+                );
+
+                assetRepository.save(asset);
+                updated++;
+
+                log.info("Updated dividend data for {}: yield={}, frequency={}, category={}",
+                        symbol,
+                        dividendData.getDividendYield(),
+                        dividendData.getDividendFrequency(),
+                        dividendData.getDividendCategory());
+
+                // Rate limiting - 150ms delay between API calls
+                Thread.sleep(150);
+
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                log.warn("Dividend update interrupted at symbol: {}", symbol);
+                break;
+            } catch (Exception e) {
+                log.warn("Failed to update dividend data for {}: {}", symbol, e.getMessage());
+                failed++;
+            }
+
+            // Log progress every 50 symbols
+            if ((i + 1) % 50 == 0) {
+                log.info("Progress: {}/{} processed, {} updated, {} failed, {} skipped",
+                        i + 1, total, updated, failed, skipped);
+            }
+        }
+
+        log.info("Dividend data update completed: {} total, {} updated, {} failed, {} skipped",
+                total, updated, failed, skipped);
+    }
+}

--- a/src/main/java/com/porcana/batch/runner/DividendDataUpdateRunner.java
+++ b/src/main/java/com/porcana/batch/runner/DividendDataUpdateRunner.java
@@ -8,9 +8,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * ApplicationRunner for updating dividend data from FMP API
@@ -26,15 +28,18 @@ public class DividendDataUpdateRunner implements ApplicationRunner {
 
     private final AssetRepository assetRepository;
     private final FmpAssetProvider fmpAssetProvider;
+    private final DividendDataUpdateRunner self;
     private final boolean enabled;
 
     public DividendDataUpdateRunner(
             AssetRepository assetRepository,
             FmpAssetProvider fmpAssetProvider,
-            @Value("${DIVIDEND_UPDATE_ENABLED:false}") boolean enabled) {
+            @Value("${DIVIDEND_UPDATE_ENABLED:false}") boolean enabled,
+            @org.springframework.context.annotation.Lazy DividendDataUpdateRunner self) {
         this.assetRepository = assetRepository;
         this.fmpAssetProvider = fmpAssetProvider;
         this.enabled = enabled;
+        this.self = self;
     }
 
     @Override
@@ -55,9 +60,11 @@ public class DividendDataUpdateRunner implements ApplicationRunner {
         }
     }
 
-    @Transactional
+    /**
+     * Main update loop - no transaction here to avoid long-running transaction
+     */
     public void updateDividendData() {
-        // Fetch all active US market assets
+        // Fetch all active US market asset IDs (read-only, quick query)
         List<Asset> usAssets = assetRepository.findByMarketAndActiveTrue(Asset.Market.US);
         log.info("Found {} active US market assets to update dividend data", usAssets.size());
 
@@ -68,6 +75,7 @@ public class DividendDataUpdateRunner implements ApplicationRunner {
 
         for (int i = 0; i < usAssets.size(); i++) {
             Asset asset = usAssets.get(i);
+            UUID assetId = asset.getId();
             String symbol = asset.getSymbol();
 
             try {
@@ -81,17 +89,8 @@ public class DividendDataUpdateRunner implements ApplicationRunner {
                     continue;
                 }
 
-                // Update asset with dividend data
-                asset.updateDividendData(
-                        dividendData.getDividendAvailable(),
-                        dividendData.getDividendYield(),
-                        dividendData.getDividendFrequency(),
-                        dividendData.getDividendCategory(),
-                        dividendData.getDividendDataStatus(),
-                        dividendData.getLastDividendDate()
-                );
-
-                assetRepository.save(asset);
+                // Update in separate transaction (short-lived)
+                self.updateSingleAsset(assetId, dividendData);
                 updated++;
 
                 log.info("Updated dividend data for {}: yield={}, frequency={}, category={}",
@@ -121,5 +120,25 @@ public class DividendDataUpdateRunner implements ApplicationRunner {
 
         log.info("Dividend data update completed: {} total, {} updated, {} failed, {} skipped",
                 total, updated, failed, skipped);
+    }
+
+    /**
+     * Update single asset in its own transaction
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateSingleAsset(UUID assetId, FmpAssetProvider.DividendData dividendData) {
+        Asset asset = assetRepository.findById(assetId)
+                .orElseThrow(() -> new IllegalArgumentException("Asset not found: " + assetId));
+
+        asset.updateDividendData(
+                dividendData.getDividendAvailable(),
+                dividendData.getDividendYield(),
+                dividendData.getDividendFrequency(),
+                dividendData.getDividendCategory(),
+                dividendData.getDividendDataStatus(),
+                dividendData.getLastDividendDate()
+        );
+
+        assetRepository.save(asset);
     }
 }

--- a/src/main/java/com/porcana/domain/asset/dto/AssetDetailResponse.java
+++ b/src/main/java/com/porcana/domain/asset/dto/AssetDetailResponse.java
@@ -1,18 +1,45 @@
 package com.porcana.domain.asset.dto;
 
+import com.porcana.domain.asset.dto.personality.AssetPersonalityResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "자산 상세 정보")
 public class AssetDetailResponse {
+
+    @Schema(description = "자산 ID")
     private final String assetId;
+
+    @Schema(description = "티커", example = "AAPL")
     private final String ticker;
+
+    @Schema(description = "종목명", example = "Apple Inc.")
     private final String name;
+
+    @Schema(description = "거래소", example = "US")
     private final String exchange;
+
+    @Schema(description = "국가", example = "US")
     private final String country;
+
+    @Schema(description = "섹터", example = "INFORMATION_TECHNOLOGY")
     private final String sector;
+
+    @Schema(description = "통화", example = "USD")
     private final String currency;
+
+    @Schema(description = "이미지 URL")
     private final String imageUrl;
+
+    @Schema(description = "설명")
     private final String description;
+
+    @Schema(description = "현재 위험도 (1-5)", example = "3")
+    private final Integer currentRiskLevel;
+
+    @Schema(description = "자산 성격 정보")
+    private final AssetPersonalityResponse personality;
 }

--- a/src/main/java/com/porcana/domain/asset/dto/personality/AssetPersonality.java
+++ b/src/main/java/com/porcana/domain/asset/dto/personality/AssetPersonality.java
@@ -1,0 +1,18 @@
+package com.porcana.domain.asset.dto.personality;
+
+import com.porcana.domain.asset.entity.personality.*;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 자산 성격 내부 Value Object
+ */
+@Getter
+@Builder
+public class AssetPersonality {
+    private final Role role;
+    private final Integer riskLevel;
+    private final ExposureType exposureType;
+    private final Persona persona;
+    private final DividendProfile dividendProfile;
+}

--- a/src/main/java/com/porcana/domain/asset/dto/personality/AssetPersonalityResponse.java
+++ b/src/main/java/com/porcana/domain/asset/dto/personality/AssetPersonalityResponse.java
@@ -1,0 +1,62 @@
+package com.porcana.domain.asset.dto.personality;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 자산 성격 API 응답 DTO
+ */
+@Getter
+@Builder
+@Schema(description = "자산 성격 정보")
+public class AssetPersonalityResponse {
+
+    @Schema(description = "역할", example = "CORE")
+    private final String role;
+
+    @Schema(description = "역할 한글명", example = "핵심")
+    private final String roleDisplayName;
+
+    @Schema(description = "역할 설명", example = "포트폴리오의 안정적 기반이 되는 종목")
+    private final String roleDescription;
+
+    @Schema(description = "위험도 (1-5)", example = "3")
+    private final Integer riskLevel;
+
+    @Schema(description = "노출 유형", example = "SINGLE_STOCK")
+    private final String exposureType;
+
+    @Schema(description = "노출 유형 한글명", example = "개별 주식")
+    private final String exposureTypeDisplayName;
+
+    @Schema(description = "페르소나", example = "GROWTH")
+    private final String persona;
+
+    @Schema(description = "페르소나 한글명", example = "성장형")
+    private final String personaDisplayName;
+
+    @Schema(description = "배당 프로필", example = "HAS_DIVIDEND")
+    private final String dividendProfile;
+
+    @Schema(description = "배당 프로필 한글명", example = "배당 있음")
+    private final String dividendProfileDisplayName;
+
+    /**
+     * AssetPersonality VO로부터 Response 생성
+     */
+    public static AssetPersonalityResponse from(AssetPersonality personality) {
+        return AssetPersonalityResponse.builder()
+                .role(personality.getRole().name())
+                .roleDisplayName(personality.getRole().getDisplayName())
+                .roleDescription(personality.getRole().getDescription())
+                .riskLevel(personality.getRiskLevel())
+                .exposureType(personality.getExposureType().name())
+                .exposureTypeDisplayName(personality.getExposureType().getDisplayName())
+                .persona(personality.getPersona().name())
+                .personaDisplayName(personality.getPersona().getDisplayName())
+                .dividendProfile(personality.getDividendProfile().name())
+                .dividendProfileDisplayName(personality.getDividendProfile().getDisplayName())
+                .build();
+    }
+}

--- a/src/main/java/com/porcana/domain/asset/entity/Asset.java
+++ b/src/main/java/com/porcana/domain/asset/entity/Asset.java
@@ -166,10 +166,28 @@ public class Asset {
 
     /**
      * 배당 데이터 일괄 업데이트
+     *
+     * @throws IllegalArgumentException 배당 수익률이 음수이거나 100%를 초과하는 경우,
+     *                                  또는 마지막 배당일이 미래인 경우
      */
     public void updateDividendData(Boolean dividendAvailable, BigDecimal dividendYield,
                                    DividendFrequency dividendFrequency, DividendCategory dividendCategory,
                                    DividendDataStatus dividendDataStatus, LocalDate lastDividendDate) {
+        // 배당 수익률 검증
+        if (dividendYield != null) {
+            if (dividendYield.compareTo(BigDecimal.ZERO) < 0) {
+                throw new IllegalArgumentException("Dividend yield cannot be negative: " + dividendYield);
+            }
+            if (dividendYield.compareTo(BigDecimal.ONE) > 0) {
+                throw new IllegalArgumentException("Dividend yield cannot exceed 100%: " + dividendYield);
+            }
+        }
+
+        // 마지막 배당일 검증
+        if (lastDividendDate != null && lastDividendDate.isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException("Last dividend date cannot be in the future: " + lastDividendDate);
+        }
+
         this.dividendAvailable = dividendAvailable;
         this.dividendYield = dividendYield;
         this.dividendFrequency = dividendFrequency;

--- a/src/main/java/com/porcana/domain/asset/entity/Asset.java
+++ b/src/main/java/com/porcana/domain/asset/entity/Asset.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -68,6 +69,28 @@ public class Asset {
     @Column(name = "image_url", length = 500)
     private String imageUrl;
 
+    // 배당 관련 필드
+    @Column(name = "dividend_available")
+    private Boolean dividendAvailable;
+
+    @Column(name = "dividend_yield", precision = 10, scale = 6)
+    private BigDecimal dividendYield;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dividend_frequency", length = 20)
+    private DividendFrequency dividendFrequency;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dividend_category", length = 30)
+    private DividendCategory dividendCategory;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dividend_data_status", length = 20)
+    private DividendDataStatus dividendDataStatus;
+
+    @Column(name = "last_dividend_date")
+    private LocalDate lastDividendDate;
+
     @Column(nullable = false)
     private LocalDate asOf;
 
@@ -82,7 +105,10 @@ public class Asset {
     @Builder
     public Asset(Market market, String symbol, String name, AssetType type, Sector sector,
                  AssetClass assetClass, List<UniverseTag> universeTags, Boolean active,
-                 String imageUrl, LocalDate asOf) {
+                 String imageUrl, Boolean dividendAvailable, BigDecimal dividendYield,
+                 DividendFrequency dividendFrequency, DividendCategory dividendCategory,
+                 DividendDataStatus dividendDataStatus, LocalDate lastDividendDate,
+                 LocalDate asOf) {
         this.market = market;
         this.symbol = symbol;
         this.name = name;
@@ -92,6 +118,12 @@ public class Asset {
         this.universeTags = universeTags != null ? universeTags : new ArrayList<>();
         this.active = active != null ? active : false;
         this.imageUrl = imageUrl;
+        this.dividendAvailable = dividendAvailable;
+        this.dividendYield = dividendYield;
+        this.dividendFrequency = dividendFrequency;
+        this.dividendCategory = dividendCategory;
+        this.dividendDataStatus = dividendDataStatus;
+        this.lastDividendDate = lastDividendDate;
         this.asOf = asOf;
     }
 
@@ -130,6 +162,20 @@ public class Asset {
 
     public void setImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    /**
+     * 배당 데이터 일괄 업데이트
+     */
+    public void updateDividendData(Boolean dividendAvailable, BigDecimal dividendYield,
+                                   DividendFrequency dividendFrequency, DividendCategory dividendCategory,
+                                   DividendDataStatus dividendDataStatus, LocalDate lastDividendDate) {
+        this.dividendAvailable = dividendAvailable;
+        this.dividendYield = dividendYield;
+        this.dividendFrequency = dividendFrequency;
+        this.dividendCategory = dividendCategory;
+        this.dividendDataStatus = dividendDataStatus;
+        this.lastDividendDate = lastDividendDate;
     }
 
     public enum Market {

--- a/src/main/java/com/porcana/domain/asset/entity/DividendCategory.java
+++ b/src/main/java/com/porcana/domain/asset/entity/DividendCategory.java
@@ -1,0 +1,25 @@
+package com.porcana.domain.asset.entity;
+
+import lombok.Getter;
+
+/**
+ * 배당 성향 원천 태그
+ */
+@Getter
+public enum DividendCategory {
+    NONE("무배당", "배당 없음"),
+    HAS_DIVIDEND("배당 있음", "배당을 지급하지만 핵심은 아님"),
+    DIVIDEND_GROWTH("배당성장", "배당 성장을 추구하는 종목"),
+    HIGH_DIVIDEND("고배당", "높은 배당수익률을 제공"),
+    REIT_LIKE("리츠형", "리츠 또는 부동산 관련 인컴"),
+    COVERED_CALL_LIKE("커버드콜형", "옵션 프리미엄 기반 분배"),
+    UNKNOWN("알 수 없음", "배당 성향 정보 없음");
+
+    private final String displayName;
+    private final String description;
+
+    DividendCategory(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/porcana/domain/asset/entity/DividendDataStatus.java
+++ b/src/main/java/com/porcana/domain/asset/entity/DividendDataStatus.java
@@ -1,0 +1,21 @@
+package com.porcana.domain.asset.entity;
+
+import lombok.Getter;
+
+/**
+ * 배당 데이터 수집 상태
+ */
+@Getter
+public enum DividendDataStatus {
+    NONE("데이터 없음", "배당 데이터가 수집되지 않음"),
+    PARTIAL("일부 수집", "일부 배당 데이터만 수집됨"),
+    VERIFIED("검증 완료", "신뢰 가능한 소스에서 수집 완료");
+
+    private final String displayName;
+    private final String description;
+
+    DividendDataStatus(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/porcana/domain/asset/entity/DividendFrequency.java
+++ b/src/main/java/com/porcana/domain/asset/entity/DividendFrequency.java
@@ -1,0 +1,25 @@
+package com.porcana.domain.asset.entity;
+
+import lombok.Getter;
+
+/**
+ * 배당 주기
+ */
+@Getter
+public enum DividendFrequency {
+    NONE("무배당", "배당 없음"),
+    MONTHLY("월배당", "매월 배당 지급"),
+    QUARTERLY("분기배당", "분기별 배당 지급"),
+    SEMI_ANNUAL("반기배당", "반기별 배당 지급"),
+    ANNUAL("연배당", "연간 1회 배당 지급"),
+    IRREGULAR("불규칙", "불규칙한 배당 지급"),
+    UNKNOWN("알 수 없음", "배당 주기 정보 없음");
+
+    private final String displayName;
+    private final String description;
+
+    DividendFrequency(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/porcana/domain/asset/entity/personality/DividendProfile.java
+++ b/src/main/java/com/porcana/domain/asset/entity/personality/DividendProfile.java
@@ -1,0 +1,22 @@
+package com.porcana.domain.asset.entity.personality;
+
+import lombok.Getter;
+
+/**
+ * 배당 특성 프로필
+ */
+@Getter
+public enum DividendProfile {
+    NONE("무배당", "배당이 없거나 매우 적음"),
+    HAS_DIVIDEND("배당 있음", "배당을 지급하지만 주 목적은 아님"),
+    DIVIDEND_FOCUSED("배당 중심", "높은 배당 수익률 추구"),
+    INCOME_CORE("인컴 핵심", "배당이 투자의 핵심 목적");
+
+    private final String displayName;
+    private final String description;
+
+    DividendProfile(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/porcana/domain/asset/entity/personality/ExposureType.java
+++ b/src/main/java/com/porcana/domain/asset/entity/personality/ExposureType.java
@@ -1,0 +1,24 @@
+package com.porcana.domain.asset.entity.personality;
+
+import lombok.Getter;
+
+/**
+ * 투자 노출 유형
+ */
+@Getter
+public enum ExposureType {
+    BROAD_INDEX("광범위 인덱스", "시장 전체를 추종"),
+    SINGLE_STOCK("개별 주식", "단일 기업에 투자"),
+    SECTOR("섹터", "특정 산업/섹터에 집중"),
+    DIVIDEND("배당", "배당 수익 중심"),
+    BOND("채권", "채권/고정수익"),
+    COMMODITY("원자재", "원자재/실물자산");
+
+    private final String displayName;
+    private final String description;
+
+    ExposureType(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/porcana/domain/asset/entity/personality/Persona.java
+++ b/src/main/java/com/porcana/domain/asset/entity/personality/Persona.java
@@ -1,0 +1,25 @@
+package com.porcana.domain.asset.entity.personality;
+
+import lombok.Getter;
+
+/**
+ * UX용 자산 성격 요약
+ */
+@Getter
+public enum Persona {
+    STABLE("안정형", "꾸준하고 예측 가능한 성과를 추구"),
+    BALANCED("균형형", "위험과 수익의 균형을 추구"),
+    GROWTH("성장형", "중장기 자본 성장을 추구"),
+    AGGRESSIVE("공격형", "고위험 고수익을 추구"),
+    DEFENSIVE("방어형", "자본 보존을 최우선"),
+    CASHFLOW("현금흐름형", "정기적인 배당/이자 수익 추구"),
+    THEMATIC("테마형", "특정 트렌드/테마에 집중");
+
+    private final String displayName;
+    private final String description;
+
+    Persona(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/porcana/domain/asset/entity/personality/Role.java
+++ b/src/main/java/com/porcana/domain/asset/entity/personality/Role.java
@@ -1,0 +1,24 @@
+package com.porcana.domain.asset.entity.personality;
+
+import lombok.Getter;
+
+/**
+ * 포트폴리오 내 자산의 역할
+ */
+@Getter
+public enum Role {
+    CORE("핵심", "포트폴리오의 안정적 기반이 되는 종목"),
+    GROWTH("성장", "높은 성장 가능성을 추구하는 종목"),
+    DEFENSIVE("방어", "시장 하락기에 안정성을 제공하는 종목"),
+    INCOME("인컴", "배당/이자를 통한 현금흐름 창출 종목"),
+    SATELLITE("위성", "특정 테마/섹터에 집중 투자하는 종목"),
+    HEDGE("헤지", "포트폴리오 위험 분산을 위한 대체자산");
+
+    private final String displayName;
+    private final String description;
+
+    Role(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/porcana/domain/asset/service/AssetService.java
+++ b/src/main/java/com/porcana/domain/asset/service/AssetService.java
@@ -8,8 +8,11 @@ import com.porcana.domain.asset.dto.AssetInMainPortfolioResponse;
 import com.porcana.domain.asset.dto.AssetLibraryResponse;
 import com.porcana.domain.asset.dto.AssetLibrarySearchCondition;
 import com.porcana.domain.asset.dto.AssetSearchResponse;
+import com.porcana.domain.asset.dto.personality.AssetPersonality;
+import com.porcana.domain.asset.dto.personality.AssetPersonalityResponse;
 import com.porcana.domain.asset.entity.Asset;
 import com.porcana.domain.asset.entity.AssetPrice;
+import com.porcana.domain.asset.service.personality.AssetPersonalityRuleEngine;
 import com.porcana.domain.portfolio.entity.Portfolio;
 import com.porcana.domain.portfolio.entity.PortfolioAsset;
 import com.porcana.domain.portfolio.repository.PortfolioAssetRepository;
@@ -63,6 +66,9 @@ public class AssetService {
         Asset asset = assetRepository.findById(assetId)
                 .orElseThrow(() -> new IllegalArgumentException("Asset not found"));
 
+        // 자산 성격 계산
+        AssetPersonality personality = AssetPersonalityRuleEngine.compute(asset);
+
         return AssetDetailResponse.builder()
                 .assetId(asset.getId().toString())
                 .ticker(asset.getSymbol())
@@ -71,8 +77,10 @@ public class AssetService {
                 .country(asset.getMarket() == Asset.Market.KR ? "KR" : "US")
                 .sector(asset.getSector() != null ? asset.getSector().name() : null)
                 .currency(asset.getMarket() == Asset.Market.KR ? "KRW" : "USD")
-                .imageUrl(null) // TODO: Add image URL logic
+                .imageUrl(asset.getImageUrl())
                 .description(null) // TODO: Add description field to Asset entity
+                .currentRiskLevel(asset.getCurrentRiskLevel())
+                .personality(AssetPersonalityResponse.from(personality))
                 .build();
     }
 

--- a/src/main/java/com/porcana/domain/asset/service/personality/AssetPersonalityRuleEngine.java
+++ b/src/main/java/com/porcana/domain/asset/service/personality/AssetPersonalityRuleEngine.java
@@ -20,6 +20,10 @@ import java.math.BigDecimal;
 @UtilityClass
 public class AssetPersonalityRuleEngine {
 
+    // 배당 수익률 임계값 상수
+    private static final BigDecimal THRESHOLD_INCOME_CORE = new BigDecimal("0.0400");      // 4% 이상 → INCOME_CORE
+    private static final BigDecimal THRESHOLD_DIVIDEND_FOCUSED = new BigDecimal("0.0200"); // 2% 이상 → DIVIDEND_FOCUSED
+
     /**
      * Asset으로부터 성격 전체를 순차적으로 계산
      */
@@ -81,7 +85,7 @@ public class AssetPersonalityRuleEngine {
             return DividendProfile.INCOME_CORE;
         }
 
-        if (yield.compareTo(new BigDecimal("0.0400")) >= 0
+        if (yield.compareTo(THRESHOLD_INCOME_CORE) >= 0
                 && (frequency == DividendFrequency.MONTHLY || frequency == DividendFrequency.QUARTERLY)) {
             return DividendProfile.INCOME_CORE;
         }
@@ -91,7 +95,7 @@ public class AssetPersonalityRuleEngine {
             return DividendProfile.DIVIDEND_FOCUSED;
         }
 
-        if (yield.compareTo(new BigDecimal("0.0200")) >= 0
+        if (yield.compareTo(THRESHOLD_DIVIDEND_FOCUSED) >= 0
                 && isDividendFriendlySector(asset.getSector())) {
             return DividendProfile.DIVIDEND_FOCUSED;
         }

--- a/src/main/java/com/porcana/domain/asset/service/personality/AssetPersonalityRuleEngine.java
+++ b/src/main/java/com/porcana/domain/asset/service/personality/AssetPersonalityRuleEngine.java
@@ -1,0 +1,263 @@
+package com.porcana.domain.asset.service.personality;
+
+import com.porcana.domain.asset.dto.personality.AssetPersonality;
+import com.porcana.domain.asset.entity.*;
+import com.porcana.domain.asset.entity.personality.*;
+import lombok.experimental.UtilityClass;
+
+import java.math.BigDecimal;
+
+/**
+ * 자산 성격 판별 규칙 엔진
+ * Asset 엔티티로부터 AssetPersonality를 계산
+ *
+ * 순차 계산 순서:
+ * 1. exposureType - 자산이 무엇에 노출되는지
+ * 2. dividendProfile - 배당 성격 판단
+ * 3. role - 포트폴리오 내 역할
+ * 4. persona - UX 페르소나
+ */
+@UtilityClass
+public class AssetPersonalityRuleEngine {
+
+    /**
+     * Asset으로부터 성격 전체를 순차적으로 계산
+     */
+    public static AssetPersonality compute(Asset asset) {
+        ExposureType exposureType = determineExposureType(asset);
+        DividendProfile dividendProfile = determineDividendProfile(asset, exposureType);
+        Role role = determineRole(asset, exposureType, dividendProfile);
+        Persona persona = determinePersona(asset, role, dividendProfile);
+
+        return AssetPersonality.builder()
+                .role(role)
+                .riskLevel(asset.getCurrentRiskLevel())
+                .exposureType(exposureType)
+                .persona(persona)
+                .dividendProfile(dividendProfile)
+                .build();
+    }
+
+    /**
+     * 투자 노출 유형 판별
+     */
+    private static ExposureType determineExposureType(Asset asset) {
+        if (asset.getType() == Asset.AssetType.ETF && asset.getAssetClass() != null) {
+            return switch (asset.getAssetClass()) {
+                case EQUITY_INDEX -> ExposureType.BROAD_INDEX;
+                case SECTOR -> ExposureType.SECTOR;
+                case DIVIDEND -> ExposureType.DIVIDEND;
+                case BOND -> ExposureType.BOND;
+                case COMMODITY -> ExposureType.COMMODITY;
+            };
+        }
+        return ExposureType.SINGLE_STOCK;
+    }
+
+    /**
+     * 배당 프로필 판별
+     * 배당 데이터 기반으로 해석 (순차 계산 2단계)
+     */
+    private static DividendProfile determineDividendProfile(Asset asset, ExposureType exposureType) {
+        // 1. ETF 배당 클래스는 가장 강한 신호
+        if (asset.getType() == Asset.AssetType.ETF && asset.getAssetClass() == AssetClass.DIVIDEND) {
+            return DividendProfile.INCOME_CORE;
+        }
+
+        // 2. 배당 데이터 없으면 보수적으로 판단
+        if (!hasReliableDividendData(asset)) {
+            // 배당 데이터 없어도 기본 휴리스틱 적용
+            return determineDividendProfileByHeuristic(asset);
+        }
+
+        BigDecimal yield = defaultZero(asset.getDividendYield());
+        DividendCategory category = asset.getDividendCategory();
+        DividendFrequency frequency = asset.getDividendFrequency();
+
+        // 3. 인컴 코어 판별
+        if (category == DividendCategory.HIGH_DIVIDEND
+                || category == DividendCategory.REIT_LIKE
+                || category == DividendCategory.COVERED_CALL_LIKE) {
+            return DividendProfile.INCOME_CORE;
+        }
+
+        if (yield.compareTo(new BigDecimal("0.0400")) >= 0
+                && (frequency == DividendFrequency.MONTHLY || frequency == DividendFrequency.QUARTERLY)) {
+            return DividendProfile.INCOME_CORE;
+        }
+
+        // 4. 배당 중심 판별
+        if (category == DividendCategory.DIVIDEND_GROWTH) {
+            return DividendProfile.DIVIDEND_FOCUSED;
+        }
+
+        if (yield.compareTo(new BigDecimal("0.0200")) >= 0
+                && isDividendFriendlySector(asset.getSector())) {
+            return DividendProfile.DIVIDEND_FOCUSED;
+        }
+
+        // 5. 배당 있음
+        if (Boolean.TRUE.equals(asset.getDividendAvailable())
+                || yield.compareTo(BigDecimal.ZERO) > 0) {
+            return DividendProfile.HAS_DIVIDEND;
+        }
+
+        return DividendProfile.NONE;
+    }
+
+    /**
+     * 배당 데이터 없을 때 휴리스틱 기반 판별 (기존 로직 유지)
+     */
+    private static DividendProfile determineDividendProfileByHeuristic(Asset asset) {
+        // Stock: 안정적인 섹터 + 낮은 리스크 → 배당 가능성
+        if (asset.getType() == Asset.AssetType.STOCK) {
+            Integer risk = asset.getCurrentRiskLevel();
+            Sector sector = asset.getSector();
+
+            // 배당 친화적 섹터 (유틸리티, 필수소비재, 헬스케어, 금융)
+            if (isDividendFriendlySector(sector) && risk != null && risk <= 2) {
+                return DividendProfile.DIVIDEND_FOCUSED;
+            }
+
+            // 대형 안정주 (낮은 리스크)
+            if (risk != null && risk <= 2) {
+                return DividendProfile.HAS_DIVIDEND;
+            }
+        }
+
+        return DividendProfile.NONE;
+    }
+
+    /**
+     * 포트폴리오 내 역할 판별 (순차 계산 3단계)
+     */
+    private static Role determineRole(Asset asset, ExposureType exposureType, DividendProfile dividendProfile) {
+        Integer risk = asset.getCurrentRiskLevel();
+
+        // ETF: assetClass 기반 판별
+        if (asset.getType() == Asset.AssetType.ETF && asset.getAssetClass() != null) {
+            return switch (asset.getAssetClass()) {
+                case EQUITY_INDEX -> Role.CORE;
+                case DIVIDEND -> Role.INCOME;
+                case BOND -> {
+                    if (risk != null && risk <= 2) yield Role.DEFENSIVE;
+                    yield Role.HEDGE;
+                }
+                case COMMODITY -> Role.HEDGE;
+                case SECTOR -> Role.SATELLITE;
+            };
+        }
+
+        // STOCK: dividendProfile 반영
+        if (dividendProfile == DividendProfile.INCOME_CORE) {
+            return Role.INCOME;
+        }
+
+        if (dividendProfile == DividendProfile.DIVIDEND_FOCUSED && isDefensiveSector(asset.getSector())) {
+            return Role.DEFENSIVE;
+        }
+
+        if (risk == null) {
+            if (isDefensiveSector(asset.getSector())) {
+                return Role.DEFENSIVE;
+            }
+            return Role.CORE;
+        }
+
+        if (risk >= 4) {
+            return Role.GROWTH;
+        }
+
+        if (risk == 3) {
+            if (isDefensiveSector(asset.getSector())) {
+                return Role.DEFENSIVE;
+            }
+            if (dividendProfile == DividendProfile.DIVIDEND_FOCUSED) {
+                return Role.CORE;
+            }
+            return Role.GROWTH;
+        }
+
+        // risk <= 2
+        if (dividendProfile == DividendProfile.DIVIDEND_FOCUSED) {
+            return Role.INCOME;
+        }
+        if (isDefensiveSector(asset.getSector())) {
+            return Role.DEFENSIVE;
+        }
+        return Role.CORE;
+    }
+
+    /**
+     * UX 페르소나 판별 (순차 계산 4단계)
+     */
+    private static Persona determinePersona(Asset asset, Role role, DividendProfile dividendProfile) {
+        Integer risk = asset.getCurrentRiskLevel();
+
+        if (role == Role.INCOME) {
+            return Persona.CASHFLOW;
+        }
+        if (role == Role.DEFENSIVE || role == Role.HEDGE) {
+            return Persona.DEFENSIVE;
+        }
+        if (role == Role.SATELLITE) {
+            return Persona.THEMATIC;
+        }
+
+        if (risk == null) {
+            return Persona.BALANCED;
+        }
+
+        if (risk >= 4) {
+            return Persona.AGGRESSIVE;
+        }
+        if (risk == 3) {
+            return Persona.GROWTH;
+        }
+        if (risk <= 2) {
+            if (dividendProfile == DividendProfile.HAS_DIVIDEND) {
+                return Persona.BALANCED;
+            }
+            return Persona.STABLE;
+        }
+
+        return Persona.BALANCED;
+    }
+
+    /**
+     * 신뢰할 수 있는 배당 데이터가 있는지 확인
+     */
+    private static boolean hasReliableDividendData(Asset asset) {
+        return asset.getDividendDataStatus() == DividendDataStatus.VERIFIED
+                || asset.getDividendDataStatus() == DividendDataStatus.PARTIAL;
+    }
+
+    /**
+     * BigDecimal null 처리
+     */
+    private static BigDecimal defaultZero(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+
+    /**
+     * 방어적 섹터인지 확인
+     */
+    private static boolean isDefensiveSector(Sector sector) {
+        if (sector == null) return false;
+        return sector == Sector.HEALTH_CARE
+                || sector == Sector.CONSUMER_STAPLES
+                || sector == Sector.UTILITIES;
+    }
+
+    /**
+     * 배당 친화적 섹터인지 확인
+     */
+    private static boolean isDividendFriendlySector(Sector sector) {
+        if (sector == null) return false;
+        return sector == Sector.UTILITIES
+                || sector == Sector.CONSUMER_STAPLES
+                || sector == Sector.HEALTH_CARE
+                || sector == Sector.FINANCIALS
+                || sector == Sector.REAL_ESTATE;
+    }
+}

--- a/src/main/java/com/porcana/domain/asset/service/personality/AssetPersonalityRuleEngine.java
+++ b/src/main/java/com/porcana/domain/asset/service/personality/AssetPersonalityRuleEngine.java
@@ -20,9 +20,9 @@ import java.math.BigDecimal;
 @UtilityClass
 public class AssetPersonalityRuleEngine {
 
-    // 배당 수익률 임계값 상수
-    private static final BigDecimal THRESHOLD_INCOME_CORE = new BigDecimal("0.0400");      // 4% 이상 → INCOME_CORE
-    private static final BigDecimal THRESHOLD_DIVIDEND_FOCUSED = new BigDecimal("0.0200"); // 2% 이상 → DIVIDEND_FOCUSED
+    // 배당 수익률 임계값 상수 (소수 기준: 0.04 = 4%)
+    private static final BigDecimal THRESHOLD_INCOME_CORE = new BigDecimal("0.0400");      // 0.04 (4%) 이상 → INCOME_CORE
+    private static final BigDecimal THRESHOLD_DIVIDEND_FOCUSED = new BigDecimal("0.0200"); // 0.02 (2%) 이상 → DIVIDEND_FOCUSED
 
     /**
      * Asset으로부터 성격 전체를 순차적으로 계산

--- a/src/main/java/com/porcana/domain/portfolio/PortfolioController.java
+++ b/src/main/java/com/porcana/domain/portfolio/PortfolioController.java
@@ -5,6 +5,7 @@ import com.porcana.domain.portfolio.command.DirectCreatePortfolioCommand;
 import com.porcana.domain.portfolio.command.UpdateAssetWeightsCommand;
 import com.porcana.domain.portfolio.command.UpdatePortfolioNameCommand;
 import com.porcana.domain.portfolio.dto.*;
+import com.porcana.domain.portfolio.dto.deck.DeckAnalysisResponse;
 import com.porcana.domain.portfolio.service.PortfolioService;
 import com.porcana.global.guest.GuestSessionExtractor;
 import com.porcana.global.security.CurrentUser;
@@ -133,6 +134,25 @@ public class PortfolioController {
         UUID guestSessionId = guestSessionExtractor.extractGuestSessionId(request);
 
         PortfolioPerformanceResponse response = portfolioService.getPortfolioPerformance(portfolioId, userId, guestSessionId, range);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "포트폴리오 덱 분석",
+            description = "포트폴리오의 구성을 분석하여 스타일, 지표, 시그널을 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "400", description = "포트폴리오를 찾을 수 없거나 권한이 없음", content = @Content)
+            }
+    )
+    @GetMapping("/{portfolioId}/deck-analysis")
+    public ResponseEntity<DeckAnalysisResponse> getDeckAnalysis(
+            @Parameter(description = "포트폴리오 ID", required = true) @PathVariable UUID portfolioId,
+            HttpServletRequest request) {
+        UUID userId = extractUserId();
+        UUID guestSessionId = guestSessionExtractor.extractGuestSessionId(request);
+
+        DeckAnalysisResponse response = portfolioService.getDeckAnalysis(portfolioId, userId, guestSessionId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/porcana/domain/portfolio/dto/deck/DeckAnalysis.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/deck/DeckAnalysis.java
@@ -1,0 +1,26 @@
+package com.porcana.domain.portfolio.dto.deck;
+
+import com.porcana.domain.portfolio.entity.deck.DeckSignal;
+import com.porcana.domain.portfolio.entity.deck.DeckStyle;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 덱 분석 결과 내부 Value Object
+ */
+@Getter
+@Builder
+public class DeckAnalysis {
+    private final DeckMetrics metrics;
+    private final DeckStyle style;
+    private final List<DeckSignal> signals;
+
+    // 텍스트 해설
+    private final String summary;
+    private final List<String> strengths;
+    private final List<String> weaknesses;
+    private final List<String> tips;
+    private final String investorFit;
+}

--- a/src/main/java/com/porcana/domain/portfolio/dto/deck/DeckAnalysisResponse.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/deck/DeckAnalysisResponse.java
@@ -1,0 +1,159 @@
+package com.porcana.domain.portfolio.dto.deck;
+
+import com.porcana.domain.portfolio.entity.deck.DeckSignal;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 덱 분석 API 응답 DTO
+ */
+@Getter
+@Builder
+@Schema(description = "포트폴리오 덱 분석 결과")
+public class DeckAnalysisResponse {
+
+    @Schema(description = "포트폴리오 ID")
+    private final UUID portfolioId;
+
+    // === 스타일 ===
+    @Schema(description = "덱 스타일", example = "BALANCED")
+    private final String style;
+
+    @Schema(description = "덱 스타일 한글명", example = "균형형")
+    private final String styleDisplayName;
+
+    @Schema(description = "덱 스타일 설명")
+    private final String styleDescription;
+
+    // === 텍스트 해설 ===
+    @Schema(description = "한 줄 요약")
+    private final String summary;
+
+    @Schema(description = "강점 목록 (최대 2개)")
+    private final List<String> strengths;
+
+    @Schema(description = "약점 목록 (최대 2개)")
+    private final List<String> weaknesses;
+
+    @Schema(description = "운영 팁 목록 (최대 2개)")
+    private final List<String> tips;
+
+    @Schema(description = "투자자 적합성")
+    private final String investorFit;
+
+    // === 지표 ===
+    @Schema(description = "가중 평균 위험도 (1.0-5.0)", example = "3.2")
+    private final Double weightedAverageRisk;
+
+    @Schema(description = "최다 섹터")
+    private final String topSector;
+
+    @Schema(description = "최다 섹터 한글명")
+    private final String topSectorKorean;
+
+    @Schema(description = "최다 섹터 비중 (%)", example = "35.5")
+    private final Double topSectorWeight;
+
+    @Schema(description = "성장형 비중 (%)", example = "45.0")
+    private final Double growthWeight;
+
+    @Schema(description = "인컴형 비중 (%)", example = "20.0")
+    private final Double incomeWeight;
+
+    @Schema(description = "방어형 비중 (%)", example = "15.0")
+    private final Double defensiveWeight;
+
+    @Schema(description = "핵심형 비중 (%)", example = "20.0")
+    private final Double coreWeight;
+
+    @Schema(description = "ETF 비중 (%)", example = "40.0")
+    private final Double etfWeight;
+
+    @Schema(description = "개별주식 비중 (%)", example = "60.0")
+    private final Double stockWeight;
+
+    @Schema(description = "미국 시장 비중 (%)", example = "70.0")
+    private final Double usWeight;
+
+    @Schema(description = "한국 시장 비중 (%)", example = "30.0")
+    private final Double krWeight;
+
+    @Schema(description = "상위 3종목 집중도 (%)", example = "45.0")
+    private final Double top3Concentration;
+
+    @Schema(description = "총 종목 수", example = "10")
+    private final Integer assetCount;
+
+    // === 시그널 ===
+    @Schema(description = "감지된 시그널 목록")
+    private final List<SignalInfo> signals;
+
+    /**
+     * 시그널 정보
+     */
+    @Getter
+    @Builder
+    @Schema(description = "시그널 정보")
+    public static class SignalInfo {
+        @Schema(description = "시그널 코드", example = "SECTOR_CONCENTRATION")
+        private final String signal;
+
+        @Schema(description = "시그널 한글명", example = "섹터 집중")
+        private final String displayName;
+
+        @Schema(description = "시그널 설명")
+        private final String description;
+
+        public static SignalInfo from(DeckSignal signal) {
+            return SignalInfo.builder()
+                    .signal(signal.name())
+                    .displayName(signal.getDisplayName())
+                    .description(signal.getDescription())
+                    .build();
+        }
+    }
+
+    /**
+     * DeckAnalysis로부터 Response 생성
+     */
+    public static DeckAnalysisResponse from(UUID portfolioId, DeckAnalysis analysis) {
+        DeckMetrics metrics = analysis.getMetrics();
+
+        return DeckAnalysisResponse.builder()
+                .portfolioId(portfolioId)
+                // 스타일
+                .style(analysis.getStyle().name())
+                .styleDisplayName(analysis.getStyle().getDisplayName())
+                .styleDescription(analysis.getStyle().getDescription())
+                // 텍스트 해설
+                .summary(analysis.getSummary())
+                .strengths(analysis.getStrengths())
+                .weaknesses(analysis.getWeaknesses())
+                .tips(analysis.getTips())
+                .investorFit(analysis.getInvestorFit())
+                // 지표
+                .weightedAverageRisk(metrics.getWeightedAverageRisk())
+                .topSector(metrics.getTopSector() != null ? metrics.getTopSector().name() : null)
+                .topSectorKorean(metrics.getTopSector() != null ? metrics.getTopSector().getKoreanName() : null)
+                .topSectorWeight(metrics.getTopSectorWeight())
+                .growthWeight(metrics.getGrowthWeight())
+                .incomeWeight(metrics.getIncomeWeight())
+                .defensiveWeight(metrics.getDefensiveWeight())
+                .coreWeight(metrics.getCoreWeight())
+                .etfWeight(metrics.getEtfWeight())
+                .stockWeight(metrics.getStockWeight())
+                .usWeight(metrics.getUsWeight())
+                .krWeight(metrics.getKrWeight())
+                .top3Concentration(metrics.getTop3Concentration())
+                .assetCount(metrics.getAssetCount())
+                // 시그널
+                .signals(analysis.getSignals().stream()
+                        .map(SignalInfo::from)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/porcana/domain/portfolio/dto/deck/DeckMetrics.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/deck/DeckMetrics.java
@@ -1,0 +1,31 @@
+package com.porcana.domain.portfolio.dto.deck;
+
+import com.porcana.domain.asset.entity.Sector;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 덱 분석 지표 내부 Value Object
+ */
+@Getter
+@Builder
+public class DeckMetrics {
+    private final Double weightedAverageRisk;
+    private final Sector topSector;
+    private final Double topSectorWeight;
+    private final Double growthWeight;
+    private final Double incomeWeight;
+    private final Double defensiveWeight;
+    private final Double hedgeWeight;
+    private final Double coreWeight;
+    private final Double etfWeight;
+    private final Double stockWeight;
+    private final Double usWeight;
+    private final Double krWeight;
+    // 배당 관련 지표
+    private final Double hasDividendWeight;      // 배당이 있는 자산 비중 (HAS_DIVIDEND + DIVIDEND_FOCUSED + INCOME_CORE)
+    private final Double dividendFocusedWeight;  // 배당 중심 자산 비중 (DIVIDEND_FOCUSED)
+    private final Double incomeCoreWeight;       // 인컴 코어 자산 비중 (INCOME_CORE)
+    private final Double top3Concentration;
+    private final Integer assetCount;
+}

--- a/src/main/java/com/porcana/domain/portfolio/dto/deck/PositionWithAsset.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/deck/PositionWithAsset.java
@@ -1,0 +1,17 @@
+package com.porcana.domain.portfolio.dto.deck;
+
+import com.porcana.domain.asset.dto.personality.AssetPersonality;
+import com.porcana.domain.asset.entity.Asset;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Asset + 비중 + Personality 조합 헬퍼
+ */
+@Getter
+@AllArgsConstructor
+public class PositionWithAsset {
+    private final Asset asset;
+    private final Double weightPct;
+    private final AssetPersonality personality;
+}

--- a/src/main/java/com/porcana/domain/portfolio/entity/deck/DeckSignal.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/deck/DeckSignal.java
@@ -1,0 +1,27 @@
+package com.porcana.domain.portfolio.entity.deck;
+
+import lombok.Getter;
+
+/**
+ * 포트폴리오 구성 시그널 (주의 사항)
+ */
+@Getter
+public enum DeckSignal {
+    SECTOR_CONCENTRATION("섹터 집중", "특정 섹터 비중이 40% 이상입니다"),
+    HIGH_RISK_EXPOSURE("고위험 노출", "고위험 종목 비중이 60% 이상입니다"),
+    LOW_DEFENSE("방어력 부족", "방어적 종목 비중이 10% 이하입니다"),
+    HIGH_CONCENTRATION("종목 집중", "상위 3종목 비중이 55% 이상입니다"),
+    HIGH_INCOME("인컴 중심", "인컴형 종목 비중이 40% 이상입니다"),
+    MARKET_IMBALANCE("시장 불균형", "특정 시장(KR/US) 비중이 80% 이상입니다"),
+    MARKET_CONCENTRATION("시장 집중", "특정 시장(KR/US) 비중이 90% 이상입니다"),
+    LOW_DIVERSIFICATION("분산 부족", "종목 수가 5개 미만입니다"),
+    DIVIDEND_TILT("배당 성향", "배당 중심 종목 비중이 25% 이상입니다");
+
+    private final String displayName;
+    private final String description;
+
+    DeckSignal(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/porcana/domain/portfolio/entity/deck/DeckStyle.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/deck/DeckStyle.java
@@ -1,0 +1,24 @@
+package com.porcana.domain.portfolio.entity.deck;
+
+import lombok.Getter;
+
+/**
+ * 포트폴리오 덱 스타일
+ */
+@Getter
+public enum DeckStyle {
+    AGGRESSIVE("공격형", "고위험 고수익을 추구하는 포트폴리오"),
+    BALANCED("균형형", "위험과 수익의 균형을 추구하는 포트폴리오"),
+    DEFENSIVE("방어형", "안정적인 자산 배분 중심 포트폴리오"),
+    CASHFLOW("현금흐름형", "배당/이자 수익 중심 포트폴리오"),
+    GROWTH("성장형", "성장주 중심 포트폴리오"),
+    THEMATIC("테마형", "특정 섹터/테마 집중 포트폴리오");
+
+    private final String displayName;
+    private final String description;
+
+    DeckStyle(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -1,14 +1,20 @@
 package com.porcana.domain.portfolio.service;
 
 import com.porcana.domain.asset.AssetRepository;
+import com.porcana.domain.asset.dto.personality.AssetPersonality;
 import com.porcana.domain.asset.entity.Asset;
+import com.porcana.domain.asset.service.personality.AssetPersonalityRuleEngine;
 import com.porcana.domain.portfolio.command.CreatePortfolioCommand;
 import com.porcana.domain.portfolio.command.DirectCreatePortfolioCommand;
 import com.porcana.domain.portfolio.command.UpdateAssetWeightsCommand;
 import com.porcana.domain.portfolio.command.UpdatePortfolioNameCommand;
 import com.porcana.domain.portfolio.dto.*;
+import com.porcana.domain.portfolio.dto.deck.DeckAnalysis;
+import com.porcana.domain.portfolio.dto.deck.DeckAnalysisResponse;
+import com.porcana.domain.portfolio.dto.deck.PositionWithAsset;
 import com.porcana.domain.portfolio.entity.*;
 import com.porcana.domain.portfolio.repository.*;
+import com.porcana.domain.portfolio.service.deck.DeckAnalysisEngine;
 import com.porcana.domain.user.entity.User;
 import com.porcana.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -767,6 +773,74 @@ public class PortfolioService {
                     "비중 수정은 오전 7:00~7:45 사이에 불가능합니다. 수익률 업데이트 중입니다."
             );
         }
+    }
+
+    /**
+     * 포트폴리오 덱 분석
+     */
+    public DeckAnalysisResponse getDeckAnalysis(UUID portfolioId, UUID userId, UUID guestSessionId) {
+        Portfolio portfolio = findPortfolioWithOwnership(portfolioId, userId, guestSessionId);
+
+        // 포트폴리오 자산 조회
+        List<PortfolioAsset> portfolioAssets = portfolioAssetRepository.findByPortfolioId(portfolioId);
+        if (portfolioAssets.isEmpty()) {
+            return DeckAnalysisResponse.from(portfolioId, DeckAnalysisEngine.analyze(List.of()));
+        }
+
+        // 자산 정보 조회
+        Set<UUID> assetIds = portfolioAssets.stream()
+                .map(PortfolioAsset::getAssetId)
+                .collect(Collectors.toSet());
+        Map<UUID, Asset> assetMap = assetRepository.findAllById(assetIds).stream()
+                .collect(Collectors.toMap(Asset::getId, a -> a));
+
+        // 최신 비중 조회 (스냅샷 기반)
+        Map<UUID, Double> latestWeights = getDeckLatestWeights(portfolioId, assetIds);
+
+        // PositionWithAsset 목록 생성
+        List<PositionWithAsset> positions = portfolioAssets.stream()
+                .map(pa -> {
+                    Asset asset = assetMap.get(pa.getAssetId());
+                    if (asset == null) return null;
+
+                    // 비중: 스냅샷 기반 또는 PortfolioAsset 기반
+                    Double weight = latestWeights.getOrDefault(pa.getAssetId(),
+                            pa.getWeightPct() != null ? pa.getWeightPct().doubleValue() : 0.0);
+
+                    // 자산 성격 계산
+                    AssetPersonality personality = AssetPersonalityRuleEngine.compute(asset);
+
+                    return new PositionWithAsset(asset, weight, personality);
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        // 덱 분석 실행
+        DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+        return DeckAnalysisResponse.from(portfolioId, analysis);
+    }
+
+    /**
+     * 덱 분석용 최신 스냅샷 기반 비중 조회
+     */
+    private Map<UUID, Double> getDeckLatestWeights(UUID portfolioId, Set<UUID> assetIds) {
+        Optional<PortfolioSnapshot> latestSnapshot = portfolioSnapshotRepository
+                .findFirstByPortfolioIdAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(portfolioId, LocalDate.now());
+
+        if (latestSnapshot.isEmpty()) {
+            return Map.of();
+        }
+
+        List<PortfolioSnapshotAsset> snapshotAssets = portfolioSnapshotAssetRepository
+                .findBySnapshotId(latestSnapshot.get().getId());
+
+        return snapshotAssets.stream()
+                .filter(sa -> assetIds.contains(sa.getAssetId()))
+                .collect(Collectors.toMap(
+                        PortfolioSnapshotAsset::getAssetId,
+                        sa -> sa.getWeight().doubleValue(),
+                        (a, b) -> a
+                ));
     }
 
     /**

--- a/src/main/java/com/porcana/domain/portfolio/service/deck/DeckAnalysisEngine.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/deck/DeckAnalysisEngine.java
@@ -67,6 +67,10 @@ public class DeckAnalysisEngine {
      */
     private static void validatePositions(List<PositionWithAsset> positions) {
         for (PositionWithAsset position : positions) {
+            if (position.getWeightPct() == null) {
+                throw new IllegalStateException(
+                        "Position weight cannot be null: " + position.getAsset().getSymbol());
+            }
             if (position.getWeightPct() < 0) {
                 throw new IllegalStateException(
                         "Position weight cannot be negative: " + position.getAsset().getSymbol()

--- a/src/main/java/com/porcana/domain/portfolio/service/deck/DeckAnalysisEngine.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/deck/DeckAnalysisEngine.java
@@ -1,0 +1,320 @@
+package com.porcana.domain.portfolio.service.deck;
+
+import com.porcana.domain.asset.entity.Asset;
+import com.porcana.domain.asset.entity.Sector;
+import com.porcana.domain.asset.entity.personality.DividendProfile;
+import com.porcana.domain.asset.entity.personality.Role;
+import com.porcana.domain.portfolio.dto.deck.DeckAnalysis;
+import com.porcana.domain.portfolio.dto.deck.DeckMetrics;
+import com.porcana.domain.portfolio.dto.deck.PositionWithAsset;
+import com.porcana.domain.portfolio.entity.deck.DeckSignal;
+import com.porcana.domain.portfolio.entity.deck.DeckStyle;
+import lombok.experimental.UtilityClass;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 덱 분석 엔진
+ * 포트폴리오 포지션 목록으로부터 분석 결과 계산
+ */
+@UtilityClass
+public class DeckAnalysisEngine {
+
+    /**
+     * 포트폴리오 분석 수행
+     */
+    public static DeckAnalysis analyze(List<PositionWithAsset> positions) {
+        if (positions == null || positions.isEmpty()) {
+            return emptyAnalysis();
+        }
+
+        // 지표 계산
+        DeckMetrics metrics = calculateMetrics(positions);
+
+        // 스타일 판별
+        DeckStyle style = determineStyle(metrics);
+
+        // 시그널 감지
+        List<DeckSignal> signals = detectSignals(metrics);
+
+        // 텍스트 해설 생성
+        String summary = DeckTextTemplate.generateSummary(style, metrics, signals);
+        List<String> strengths = DeckTextTemplate.generateStrengths(style, metrics, signals);
+        List<String> weaknesses = DeckTextTemplate.generateWeaknesses(style, metrics, signals);
+        List<String> tips = DeckTextTemplate.generateTips(style, metrics, signals);
+        String investorFit = DeckTextTemplate.generateInvestorFit(style, metrics);
+
+        return DeckAnalysis.builder()
+                .metrics(metrics)
+                .style(style)
+                .signals(signals)
+                .summary(summary)
+                .strengths(strengths)
+                .weaknesses(weaknesses)
+                .tips(tips)
+                .investorFit(investorFit)
+                .build();
+    }
+
+    /**
+     * 지표 계산
+     */
+    private static DeckMetrics calculateMetrics(List<PositionWithAsset> positions) {
+        double totalWeight = positions.stream()
+                .mapToDouble(PositionWithAsset::getWeightPct)
+                .sum();
+
+        if (totalWeight <= 0) {
+            totalWeight = 100.0; // 방어적 처리
+        }
+
+        // 위험도: null 제외 자산 비중만 분모로 사용
+        double riskWeightSum = positions.stream()
+                .filter(p -> p.getAsset().getCurrentRiskLevel() != null)
+                .mapToDouble(PositionWithAsset::getWeightPct)
+                .sum();
+
+        double weightedRisk = riskWeightSum > 0
+                ? positions.stream()
+                    .filter(p -> p.getAsset().getCurrentRiskLevel() != null)
+                    .mapToDouble(p -> p.getWeightPct() * p.getAsset().getCurrentRiskLevel())
+                    .sum() / riskWeightSum
+                : 0.0;
+
+        // 섹터별 비중
+        Map<Sector, Double> sectorWeights = positions.stream()
+                .filter(p -> p.getAsset().getSector() != null)
+                .collect(Collectors.groupingBy(
+                        p -> p.getAsset().getSector(),
+                        Collectors.summingDouble(PositionWithAsset::getWeightPct)
+                ));
+
+        Sector topSector = sectorWeights.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+
+        double topSectorWeight = topSector == null ? 0.0 : sectorWeights.get(topSector);
+
+        // Role별 비중 계산
+        double growthWeight = calculateRoleWeight(positions, Role.GROWTH);
+        double incomeWeight = calculateRoleWeight(positions, Role.INCOME);
+        double defensiveWeight = calculateRoleWeight(positions, Role.DEFENSIVE);
+        double hedgeWeight = calculateRoleWeight(positions, Role.HEDGE);
+        double coreWeight = calculateRoleWeight(positions, Role.CORE);
+
+        // 타입별 비중 (직접 합산)
+        double etfWeight = positions.stream()
+                .filter(p -> p.getAsset().getType() == Asset.AssetType.ETF)
+                .mapToDouble(PositionWithAsset::getWeightPct)
+                .sum();
+
+        double stockWeight = positions.stream()
+                .filter(p -> p.getAsset().getType() == Asset.AssetType.STOCK)
+                .mapToDouble(PositionWithAsset::getWeightPct)
+                .sum();
+
+        // 시장별 비중 (직접 합산)
+        double usWeight = positions.stream()
+                .filter(p -> p.getAsset().getMarket() == Asset.Market.US)
+                .mapToDouble(PositionWithAsset::getWeightPct)
+                .sum();
+
+        double krWeight = positions.stream()
+                .filter(p -> p.getAsset().getMarket() == Asset.Market.KR)
+                .mapToDouble(PositionWithAsset::getWeightPct)
+                .sum();
+
+        // 배당 관련 비중 계산
+        double hasDividendWeight = calculateDividendProfileWeight(positions, DividendProfile.HAS_DIVIDEND)
+                + calculateDividendProfileWeight(positions, DividendProfile.DIVIDEND_FOCUSED)
+                + calculateDividendProfileWeight(positions, DividendProfile.INCOME_CORE);
+
+        double dividendFocusedWeight = calculateDividendProfileWeight(positions, DividendProfile.DIVIDEND_FOCUSED);
+
+        double incomeCoreWeight = calculateDividendProfileWeight(positions, DividendProfile.INCOME_CORE);
+
+        // 집중도 (상위 3종목)
+        List<Double> sortedWeights = positions.stream()
+                .map(PositionWithAsset::getWeightPct)
+                .sorted(Comparator.reverseOrder())
+                .toList();
+
+        double top3Concentration = sortedWeights.stream()
+                .limit(3)
+                .mapToDouble(Double::doubleValue)
+                .sum();
+
+        return DeckMetrics.builder()
+                .weightedAverageRisk(round1(weightedRisk))
+                .topSector(topSector)
+                .topSectorWeight(round1(topSectorWeight))
+                .growthWeight(round1(growthWeight))
+                .incomeWeight(round1(incomeWeight))
+                .defensiveWeight(round1(defensiveWeight))
+                .hedgeWeight(round1(hedgeWeight))
+                .coreWeight(round1(coreWeight))
+                .etfWeight(round1(etfWeight))
+                .stockWeight(round1(stockWeight))
+                .usWeight(round1(usWeight))
+                .krWeight(round1(krWeight))
+                .hasDividendWeight(round1(hasDividendWeight))
+                .dividendFocusedWeight(round1(dividendFocusedWeight))
+                .incomeCoreWeight(round1(incomeCoreWeight))
+                .top3Concentration(round1(top3Concentration))
+                .assetCount(positions.size())
+                .build();
+    }
+
+    /**
+     * 특정 Role의 비중 계산
+     */
+    private static double calculateRoleWeight(List<PositionWithAsset> positions, Role role) {
+        return positions.stream()
+                .filter(p -> p.getPersonality() != null && p.getPersonality().getRole() == role)
+                .mapToDouble(PositionWithAsset::getWeightPct)
+                .sum();
+    }
+
+    /**
+     * 특정 DividendProfile의 비중 계산
+     */
+    private static double calculateDividendProfileWeight(List<PositionWithAsset> positions, DividendProfile profile) {
+        return positions.stream()
+                .filter(p -> p.getPersonality() != null && p.getPersonality().getDividendProfile() == profile)
+                .mapToDouble(PositionWithAsset::getWeightPct)
+                .sum();
+    }
+
+    /**
+     * 소수점 1자리 반올림
+     */
+    private static double round1(double value) {
+        return Math.round(value * 10) / 10.0;
+    }
+
+    /**
+     * 덱 스타일 판별
+     */
+    private static DeckStyle determineStyle(DeckMetrics metrics) {
+        // 테마 집중이 아주 강하면 먼저 반영
+        if (metrics.getTopSectorWeight() >= 55 && metrics.getGrowthWeight() >= 40) {
+            return DeckStyle.THEMATIC;
+        }
+
+        // 공격형: 평균 위험도 4 이상 + 성장 비중 60% 이상
+        if (metrics.getWeightedAverageRisk() >= 4.0 && metrics.getGrowthWeight() >= 60) {
+            return DeckStyle.AGGRESSIVE;
+        }
+
+        // 현금흐름형: 인컴 비중 40% 이상 또는 인컴 코어 비중 30% 이상
+        if (metrics.getIncomeWeight() >= 40 || metrics.getIncomeCoreWeight() >= 30) {
+            return DeckStyle.CASHFLOW;
+        }
+
+        // 방어형: 방어 + 헤지 비중 40% 이상
+        if (metrics.getDefensiveWeight() + metrics.getHedgeWeight() >= 40) {
+            return DeckStyle.DEFENSIVE;
+        }
+
+        // 성장형: 성장 비중 50% 이상
+        if (metrics.getGrowthWeight() >= 50) {
+            return DeckStyle.GROWTH;
+        }
+
+        // 테마형: 최다 섹터 비중 50% 이상
+        if (metrics.getTopSectorWeight() >= 50) {
+            return DeckStyle.THEMATIC;
+        }
+
+        // 기본: 균형형
+        return DeckStyle.BALANCED;
+    }
+
+    /**
+     * 시그널 감지
+     */
+    private static List<DeckSignal> detectSignals(DeckMetrics metrics) {
+        List<DeckSignal> signals = new ArrayList<>();
+
+        // 섹터 집중 (40% 이상)
+        if (metrics.getTopSectorWeight() >= 40) {
+            signals.add(DeckSignal.SECTOR_CONCENTRATION);
+        }
+
+        // 고위험 노출 (성장 60% 이상 + 평균 위험 4 이상)
+        if (metrics.getGrowthWeight() >= 60 && metrics.getWeightedAverageRisk() >= 4.0) {
+            signals.add(DeckSignal.HIGH_RISK_EXPOSURE);
+        }
+
+        // 방어력 부족 (방어 + 헤지 10% 이하)
+        if (metrics.getDefensiveWeight() + metrics.getHedgeWeight() <= 10) {
+            signals.add(DeckSignal.LOW_DEFENSE);
+        }
+
+        // 종목 집중 (상위 3종목 55% 이상)
+        if (metrics.getTop3Concentration() >= 55) {
+            signals.add(DeckSignal.HIGH_CONCENTRATION);
+        }
+
+        // 인컴 중심 (인컴 비중 40% 이상 또는 인컴 코어 30% 이상)
+        if (metrics.getIncomeWeight() >= 40 || metrics.getIncomeCoreWeight() >= 30) {
+            signals.add(DeckSignal.HIGH_INCOME);
+        }
+
+        // 시장 집중 (90% 이상)
+        if (metrics.getUsWeight() >= 90 || metrics.getKrWeight() >= 90) {
+            signals.add(DeckSignal.MARKET_CONCENTRATION);
+        }
+        // 시장 불균형 (80% 이상, 90% 미만)
+        else if (metrics.getUsWeight() >= 80 || metrics.getKrWeight() >= 80) {
+            signals.add(DeckSignal.MARKET_IMBALANCE);
+        }
+
+        // 분산 부족 (5종목 미만 + 상위 3종목 60% 이상)
+        if (metrics.getAssetCount() < 5 && metrics.getTop3Concentration() >= 60) {
+            signals.add(DeckSignal.LOW_DIVERSIFICATION);
+        }
+
+        // 배당 성향 (배당 중심 종목 비중 25% 이상)
+        if (metrics.getDividendFocusedWeight() >= 25) {
+            signals.add(DeckSignal.DIVIDEND_TILT);
+        }
+
+        return signals;
+    }
+
+    /**
+     * 빈 분석 결과
+     */
+    private static DeckAnalysis emptyAnalysis() {
+        return DeckAnalysis.builder()
+                .metrics(DeckMetrics.builder()
+                        .weightedAverageRisk(0.0)
+                        .topSectorWeight(0.0)
+                        .growthWeight(0.0)
+                        .incomeWeight(0.0)
+                        .defensiveWeight(0.0)
+                        .hedgeWeight(0.0)
+                        .coreWeight(0.0)
+                        .etfWeight(0.0)
+                        .stockWeight(0.0)
+                        .usWeight(0.0)
+                        .krWeight(0.0)
+                        .hasDividendWeight(0.0)
+                        .dividendFocusedWeight(0.0)
+                        .incomeCoreWeight(0.0)
+                        .top3Concentration(0.0)
+                        .assetCount(0)
+                        .build())
+                .style(DeckStyle.BALANCED)
+                .signals(List.of())
+                .summary("포트폴리오에 자산이 없습니다")
+                .strengths(List.of())
+                .weaknesses(List.of())
+                .tips(List.of("자산을 추가하여 포트폴리오를 구성해보세요"))
+                .investorFit("")
+                .build();
+    }
+}

--- a/src/main/java/com/porcana/domain/portfolio/service/deck/DeckAnalysisEngine.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/deck/DeckAnalysisEngine.java
@@ -23,11 +23,16 @@ public class DeckAnalysisEngine {
 
     /**
      * 포트폴리오 분석 수행
+     *
+     * @throws IllegalStateException 포지션 비중이 음수인 경우
      */
     public static DeckAnalysis analyze(List<PositionWithAsset> positions) {
         if (positions == null || positions.isEmpty()) {
             return emptyAnalysis();
         }
+
+        // 포지션 유효성 검증
+        validatePositions(positions);
 
         // 지표 계산
         DeckMetrics metrics = calculateMetrics(positions);
@@ -58,6 +63,23 @@ public class DeckAnalysisEngine {
     }
 
     /**
+     * 포지션 유효성 검증
+     */
+    private static void validatePositions(List<PositionWithAsset> positions) {
+        for (PositionWithAsset position : positions) {
+            if (position.getWeightPct() < 0) {
+                throw new IllegalStateException(
+                        "Position weight cannot be negative: " + position.getAsset().getSymbol()
+                                + " = " + position.getWeightPct() + "%");
+            }
+            if (position.getPersonality() == null) {
+                throw new IllegalStateException(
+                        "Position personality must be computed before analysis: " + position.getAsset().getSymbol());
+            }
+        }
+    }
+
+    /**
      * 지표 계산
      */
     private static DeckMetrics calculateMetrics(List<PositionWithAsset> positions) {
@@ -66,7 +88,7 @@ public class DeckAnalysisEngine {
                 .sum();
 
         if (totalWeight <= 0) {
-            totalWeight = 100.0; // 방어적 처리
+            throw new IllegalStateException("Total portfolio weight must be positive: " + totalWeight);
         }
 
         // 위험도: null 제외 자산 비중만 분모로 사용

--- a/src/main/java/com/porcana/domain/portfolio/service/deck/DeckTextTemplate.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/deck/DeckTextTemplate.java
@@ -1,0 +1,248 @@
+package com.porcana.domain.portfolio.service.deck;
+
+import com.porcana.domain.portfolio.dto.deck.DeckMetrics;
+import com.porcana.domain.portfolio.entity.deck.DeckSignal;
+import com.porcana.domain.portfolio.entity.deck.DeckStyle;
+import lombok.experimental.UtilityClass;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 덱 해설 텍스트 템플릿 생성기
+ * DeckStyle과 DeckSignal 기반으로 문장 조합
+ */
+@UtilityClass
+public class DeckTextTemplate {
+
+    /**
+     * 한 줄 요약 생성
+     */
+    public static String generateSummary(DeckStyle style, DeckMetrics metrics, List<DeckSignal> signals) {
+        return switch (style) {
+            case AGGRESSIVE -> "고위험 고수익을 추구하는 공격적인 포트폴리오입니다";
+            case BALANCED -> {
+                if (signals.contains(DeckSignal.DIVIDEND_TILT)) {
+                    yield "성장과 배당을 균형있게 추구하는 포트폴리오입니다";
+                }
+                if (signals.contains(DeckSignal.HIGH_INCOME)) {
+                    yield "성장주 중심이지만 일부 배당 자산을 포함한 균형형 포트폴리오입니다";
+                }
+                yield "위험과 수익의 균형을 추구하는 포트폴리오입니다";
+            }
+            case DEFENSIVE -> {
+                if (metrics.getIncomeCoreWeight() >= 20) {
+                    yield "안정적인 배당과 방어적 자산 중심의 보수적 포트폴리오입니다";
+                }
+                yield "안정적인 자산 중심의 방어적 포트폴리오입니다";
+            }
+            case CASHFLOW -> {
+                if (metrics.getIncomeCoreWeight() >= 40) {
+                    yield "배당 수익을 핵심으로 하는 인컴 중심 포트폴리오입니다";
+                }
+                yield "배당 수익을 중심으로 현금흐름을 추구하는 포트폴리오입니다";
+            }
+            case GROWTH -> {
+                if (signals.contains(DeckSignal.DIVIDEND_TILT)) {
+                    yield "성장을 추구하면서 배당도 고려한 포트폴리오입니다";
+                }
+                yield "중장기 성장을 추구하는 성장 중심 포트폴리오입니다";
+            }
+            case THEMATIC -> "특정 섹터/테마에 집중한 테마형 포트폴리오입니다";
+        };
+    }
+
+    /**
+     * 강점 생성 (최대 2개)
+     */
+    public static List<String> generateStrengths(DeckStyle style, DeckMetrics metrics, List<DeckSignal> signals) {
+        List<String> strengths = new ArrayList<>();
+
+        // 스타일별 강점
+        switch (style) {
+            case AGGRESSIVE -> strengths.add("상승장에서 높은 수익 잠재력");
+            case BALANCED -> strengths.add("성장성과 안정성을 동시에 추구");
+            case DEFENSIVE -> strengths.add("하락장에서 손실 방어 가능");
+            case CASHFLOW -> strengths.add("정기적인 배당 수익 기대");
+            case GROWTH -> strengths.add("중장기 자본 성장 추구");
+            case THEMATIC -> strengths.add("특정 트렌드 수혜 기대");
+        }
+
+        // 배당 관련 강점
+        if (metrics.getIncomeCoreWeight() >= 30) {
+            strengths.add("인컴 자산이 안정적인 현금흐름 제공");
+        } else if (signals.contains(DeckSignal.DIVIDEND_TILT)) {
+            strengths.add("배당 자산이 포트폴리오 안정성 강화");
+        } else if (signals.contains(DeckSignal.HIGH_INCOME)) {
+            strengths.add("배당 자산이 변동성 완충 역할 수행");
+        }
+
+        // 분산 효과 관련 강점
+        if (metrics.getHasDividendWeight() >= 40 && metrics.getGrowthWeight() >= 30) {
+            strengths.add("성장과 배당의 균형잡힌 구성");
+        }
+        if (metrics.getEtfWeight() >= 50) {
+            strengths.add("ETF 비중이 높아 분산 효과 우수");
+        }
+        if (metrics.getAssetCount() >= 8) {
+            strengths.add("충분한 종목 수로 분산 투자 실현");
+        }
+        if (!signals.contains(DeckSignal.MARKET_IMBALANCE) && !signals.contains(DeckSignal.MARKET_CONCENTRATION)) {
+            if (metrics.getUsWeight() >= 30 && metrics.getKrWeight() >= 30) {
+                strengths.add("글로벌 분산 투자 구조");
+            }
+        }
+
+        // 헤지 자산 강점
+        if (metrics.getHedgeWeight() >= 15) {
+            strengths.add("헤지 자산이 포트폴리오 리스크 분산");
+        }
+
+        return strengths.stream().limit(2).toList();
+    }
+
+    /**
+     * 약점 생성 (최대 2개)
+     */
+    public static List<String> generateWeaknesses(DeckStyle style, DeckMetrics metrics, List<DeckSignal> signals) {
+        List<String> weaknesses = new ArrayList<>();
+
+        // 시그널 기반 약점
+        if (signals.contains(DeckSignal.SECTOR_CONCENTRATION)) {
+            weaknesses.add("특정 섹터 편중으로 분산 효과 제한");
+        }
+        if (signals.contains(DeckSignal.HIGH_RISK_EXPOSURE)) {
+            weaknesses.add("고위험 자산 비중으로 변동성 존재");
+        }
+        if (signals.contains(DeckSignal.LOW_DEFENSE)) {
+            weaknesses.add("방어적 자산 부족으로 하락장 취약");
+        }
+        if (signals.contains(DeckSignal.HIGH_CONCENTRATION)) {
+            weaknesses.add("상위 종목 집중으로 개별 종목 리스크 존재");
+        }
+        if (signals.contains(DeckSignal.MARKET_CONCENTRATION)) {
+            weaknesses.add("특정 시장 과도 집중으로 지역 리스크 높음");
+        } else if (signals.contains(DeckSignal.MARKET_IMBALANCE)) {
+            weaknesses.add("특정 시장 편중으로 지역 리스크 존재");
+        }
+        if (signals.contains(DeckSignal.LOW_DIVERSIFICATION)) {
+            weaknesses.add("종목 수 부족으로 분산 효과 제한");
+        }
+
+        // 배당 관련 약점 (스타일별로 다르게)
+        if (style == DeckStyle.CASHFLOW && metrics.getGrowthWeight() < 20) {
+            weaknesses.add("성장 자산 부족으로 자본 증식 제한");
+        }
+        if (signals.contains(DeckSignal.DIVIDEND_TILT) && style == DeckStyle.GROWTH) {
+            // 성장형인데 배당 성향이 있으면 성장 잠재력 제한 가능
+            weaknesses.add("배당 자산 비중으로 성장 잠재력 일부 제한");
+        }
+
+        // 스타일별 기본 약점
+        if (weaknesses.isEmpty()) {
+            switch (style) {
+                case AGGRESSIVE -> weaknesses.add("하락장에서 큰 손실 가능성");
+                case DEFENSIVE -> weaknesses.add("상승장에서 수익률 제한");
+                case CASHFLOW -> weaknesses.add("성장 잠재력 제한");
+                case THEMATIC -> weaknesses.add("테마 쇠퇴 시 리스크");
+                default -> weaknesses.add("시장 상황에 따른 변동성 존재");
+            }
+        }
+
+        return weaknesses.stream().limit(2).toList();
+    }
+
+    /**
+     * 운영 팁 생성 (최대 2개)
+     */
+    public static List<String> generateTips(DeckStyle style, DeckMetrics metrics, List<DeckSignal> signals) {
+        List<String> tips = new ArrayList<>();
+
+        // 시그널 기반 팁
+        if (signals.contains(DeckSignal.SECTOR_CONCENTRATION)) {
+            tips.add("다른 섹터 자산 추가로 분산 효과 강화 고려");
+        }
+        if (signals.contains(DeckSignal.HIGH_RISK_EXPOSURE)) {
+            tips.add("성장주 과열 시 일부 이익 실현 고려");
+        }
+        if (signals.contains(DeckSignal.LOW_DEFENSE)) {
+            tips.add("방어적 자산(채권, 배당주) 추가 검토");
+        }
+        if (signals.contains(DeckSignal.HIGH_CONCENTRATION)) {
+            tips.add("비중 조절로 개별 종목 리스크 분산 검토");
+        }
+        if (signals.contains(DeckSignal.MARKET_CONCENTRATION)) {
+            tips.add("다른 시장 자산 추가로 지역 분산 권장");
+        }
+        if (signals.contains(DeckSignal.LOW_DIVERSIFICATION)) {
+            tips.add("종목 추가로 분산 효과 강화 권장");
+        }
+
+        // 배당 관련 팁
+        if (signals.contains(DeckSignal.DIVIDEND_TILT) || signals.contains(DeckSignal.HIGH_INCOME)) {
+            if (style != DeckStyle.CASHFLOW) {
+                tips.add("배당 재투자로 복리 효과 극대화");
+            }
+        }
+        if (style == DeckStyle.CASHFLOW) {
+            if (metrics.getIncomeCoreWeight() < 40) {
+                tips.add("고배당 ETF 추가로 인컴 강화 고려");
+            } else {
+                tips.add("배당 재투자로 복리 효과 극대화");
+            }
+        }
+
+        // 스타일별 기본 팁
+        if (tips.isEmpty()) {
+            switch (style) {
+                case AGGRESSIVE -> tips.add("주기적인 리밸런싱으로 리스크 관리 필요");
+                case BALANCED -> tips.add("목표 비중 유지를 위한 정기 리밸런싱 권장");
+                case DEFENSIVE -> tips.add("금리 변동에 따른 채권 비중 조정 검토");
+                case CASHFLOW -> tips.add("배당 재투자로 복리 효과 극대화");
+                case GROWTH -> tips.add("장기 보유 관점에서 단기 변동성 인내");
+                case THEMATIC -> tips.add("테마 트렌드 모니터링 필요");
+            }
+        }
+
+        // 일반적인 팁 추가
+        if (tips.size() < 2 && metrics.getAssetCount() >= 5) {
+            tips.add("분기별 리밸런싱으로 목표 비중 유지 권장");
+        }
+
+        return tips.stream().limit(2).toList();
+    }
+
+    /**
+     * 투자자 적합성 생성
+     */
+    public static String generateInvestorFit(DeckStyle style, DeckMetrics metrics) {
+        return switch (style) {
+            case AGGRESSIVE -> "고수익을 추구하며 높은 변동성을 감내할 수 있는 공격적 투자자";
+            case BALANCED -> {
+                if (metrics.getHasDividendWeight() >= 30) {
+                    yield "성장과 배당을 균형있게 추구하는 중립적 투자자";
+                }
+                yield "중장기 성장과 안정성을 동시에 추구하는 투자자";
+            }
+            case DEFENSIVE -> {
+                if (metrics.getIncomeCoreWeight() >= 20) {
+                    yield "안정적인 배당 수익과 원금 보존을 중시하는 보수적 투자자";
+                }
+                yield "원금 보존을 최우선으로 하는 안정 추구 투자자";
+            }
+            case CASHFLOW -> {
+                if (metrics.getIncomeCoreWeight() >= 40) {
+                    yield "정기적인 배당 수익을 최우선으로 하는 인컴 중심 투자자";
+                }
+                yield "정기적인 현금흐름이 필요한 인컴 추구 투자자";
+            }
+            case GROWTH -> {
+                if (metrics.getDividendFocusedWeight() >= 20) {
+                    yield "성장을 추구하되 배당 수익도 고려하는 균형 지향 투자자";
+                }
+                yield "장기적 자본 성장을 목표로 하는 성장 지향 투자자";
+            }
+            case THEMATIC -> "특정 섹터/트렌드에 확신을 가진 집중 투자자";
+        };
+    }
+}

--- a/src/main/resources/db/migration/V25__add_dividend_fields_to_assets.sql
+++ b/src/main/resources/db/migration/V25__add_dividend_fields_to_assets.sql
@@ -1,0 +1,31 @@
+-- Asset 테이블에 배당 관련 필드 추가
+
+-- 배당 여부
+ALTER TABLE assets ADD COLUMN dividend_available BOOLEAN;
+
+-- 배당수익률 (소수 기준, 예: 0.0350 = 3.50%)
+ALTER TABLE assets ADD COLUMN dividend_yield DECIMAL(10, 6);
+
+-- 배당 주기
+ALTER TABLE assets ADD COLUMN dividend_frequency VARCHAR(20);
+
+-- 배당 성향 태그
+ALTER TABLE assets ADD COLUMN dividend_category VARCHAR(30);
+
+-- 배당 데이터 수집 상태
+ALTER TABLE assets ADD COLUMN dividend_data_status VARCHAR(20);
+
+-- 최근 배당 기준일
+ALTER TABLE assets ADD COLUMN last_dividend_date DATE;
+
+-- 인덱스: 배당 관련 조회 최적화
+CREATE INDEX idx_assets_dividend_available ON assets (dividend_available) WHERE dividend_available = true;
+CREATE INDEX idx_assets_dividend_yield ON assets (dividend_yield) WHERE dividend_yield IS NOT NULL;
+CREATE INDEX idx_assets_dividend_category ON assets (dividend_category) WHERE dividend_category IS NOT NULL;
+
+COMMENT ON COLUMN assets.dividend_available IS '배당 지급 여부';
+COMMENT ON COLUMN assets.dividend_yield IS '연환산 배당수익률 (소수 기준)';
+COMMENT ON COLUMN assets.dividend_frequency IS '배당 주기 (NONE, MONTHLY, QUARTERLY, SEMI_ANNUAL, ANNUAL, IRREGULAR, UNKNOWN)';
+COMMENT ON COLUMN assets.dividend_category IS '배당 성향 (NONE, HAS_DIVIDEND, DIVIDEND_GROWTH, HIGH_DIVIDEND, REIT_LIKE, COVERED_CALL_LIKE, UNKNOWN)';
+COMMENT ON COLUMN assets.dividend_data_status IS '배당 데이터 수집 상태 (NONE, PARTIAL, VERIFIED)';
+COMMENT ON COLUMN assets.last_dividend_date IS '최근 배당 기준일';

--- a/src/test/java/com/porcana/domain/asset/service/personality/AssetPersonalityRuleEngineTest.java
+++ b/src/test/java/com/porcana/domain/asset/service/personality/AssetPersonalityRuleEngineTest.java
@@ -1,0 +1,346 @@
+package com.porcana.domain.asset.service.personality;
+
+import com.porcana.BaseIntegrationTest;
+import com.porcana.domain.asset.dto.personality.AssetPersonality;
+import com.porcana.domain.asset.entity.Asset;
+import com.porcana.domain.asset.entity.personality.*;
+import com.porcana.domain.asset.AssetRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql(scripts = "/sql/personality-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class AssetPersonalityRuleEngineTest extends BaseIntegrationTest {
+
+    @Autowired
+    private AssetRepository assetRepository;
+
+    // ETF IDs
+    private static final UUID EQUITY_INDEX_ETF_LOW_RISK = UUID.fromString("10000000-0000-0000-0000-000000000001");
+    private static final UUID EQUITY_INDEX_ETF_MID_RISK = UUID.fromString("10000000-0000-0000-0000-000000000002");
+    private static final UUID DIVIDEND_ETF = UUID.fromString("10000000-0000-0000-0000-000000000003");
+    private static final UUID BOND_ETF_LOW_RISK = UUID.fromString("10000000-0000-0000-0000-000000000004");
+    private static final UUID BOND_ETF_HIGH_RISK = UUID.fromString("10000000-0000-0000-0000-000000000005");
+    private static final UUID COMMODITY_ETF = UUID.fromString("10000000-0000-0000-0000-000000000006");
+    private static final UUID SECTOR_ETF = UUID.fromString("10000000-0000-0000-0000-000000000007");
+
+    // Stock IDs
+    private static final UUID HIGH_RISK_IT_STOCK = UUID.fromString("20000000-0000-0000-0000-000000000001");
+    private static final UUID MID_RISK_IT_STOCK = UUID.fromString("20000000-0000-0000-0000-000000000002");
+    private static final UUID LOW_RISK_HEALTHCARE_STOCK = UUID.fromString("20000000-0000-0000-0000-000000000003");
+    private static final UUID LOW_RISK_IT_STOCK = UUID.fromString("20000000-0000-0000-0000-000000000004");
+    private static final UUID LOW_RISK_UTILITIES_STOCK = UUID.fromString("20000000-0000-0000-0000-000000000005");
+    private static final UUID HIGH_RISK_IT_STOCK_2 = UUID.fromString("20000000-0000-0000-0000-000000000006");
+
+    // Dividend Stock IDs
+    private static final UUID HIGH_DIVIDEND_STOCK = UUID.fromString("30000000-0000-0000-0000-000000000001");
+    private static final UUID DIVIDEND_GROWTH_STOCK = UUID.fromString("30000000-0000-0000-0000-000000000002");
+    private static final UUID MONTHLY_DIVIDEND_STOCK = UUID.fromString("30000000-0000-0000-0000-000000000003");
+    private static final UUID INCOME_CORE_STOCK = UUID.fromString("30000000-0000-0000-0000-000000000004");
+
+    @Nested
+    @DisplayName("ETF 성격 판별")
+    class EtfPersonalityTest {
+
+        @Test
+        @DisplayName("EQUITY_INDEX ETF (저위험) → CORE 역할, BROAD_INDEX 노출, STABLE 페르소나")
+        void equityIndexEtf_lowRisk_shouldBeCoreStable() {
+            // given
+            Asset etf = assetRepository.findById(EQUITY_INDEX_ETF_LOW_RISK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(etf);
+
+            // then
+            assertThat(personality.getRole()).isEqualTo(Role.CORE);
+            assertThat(personality.getExposureType()).isEqualTo(ExposureType.BROAD_INDEX);
+            assertThat(personality.getPersona()).isEqualTo(Persona.STABLE);
+        }
+
+        @Test
+        @DisplayName("EQUITY_INDEX ETF (중위험) → CORE 역할, GROWTH 페르소나")
+        void equityIndexEtf_midRisk_shouldBeCoreGrowth() {
+            // given
+            Asset etf = assetRepository.findById(EQUITY_INDEX_ETF_MID_RISK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(etf);
+
+            // then
+            assertThat(personality.getRole()).isEqualTo(Role.CORE);
+            assertThat(personality.getExposureType()).isEqualTo(ExposureType.BROAD_INDEX);
+            // CORE 역할이면서 risk=3 → GROWTH 페르소나
+            assertThat(personality.getPersona()).isEqualTo(Persona.GROWTH);
+        }
+
+        @Test
+        @DisplayName("DIVIDEND ETF → INCOME 역할, 현금흐름형 페르소나")
+        void dividendEtf_shouldBeIncome() {
+            // given
+            Asset etf = assetRepository.findById(DIVIDEND_ETF).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(etf);
+
+            // then
+            assertThat(personality.getRole()).isEqualTo(Role.INCOME);
+            assertThat(personality.getExposureType()).isEqualTo(ExposureType.DIVIDEND);
+            assertThat(personality.getPersona()).isEqualTo(Persona.CASHFLOW);
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.INCOME_CORE);
+        }
+
+        @Test
+        @DisplayName("BOND ETF (저위험) → DEFENSIVE 역할, DEFENSIVE 페르소나")
+        void bondEtf_lowRisk_shouldBeDefensive() {
+            // given
+            Asset etf = assetRepository.findById(BOND_ETF_LOW_RISK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(etf);
+
+            // then
+            assertThat(personality.getRole()).isEqualTo(Role.DEFENSIVE);
+            assertThat(personality.getExposureType()).isEqualTo(ExposureType.BOND);
+            // Role.DEFENSIVE → Persona.DEFENSIVE
+            assertThat(personality.getPersona()).isEqualTo(Persona.DEFENSIVE);
+        }
+
+        @Test
+        @DisplayName("BOND ETF (고위험) → HEDGE 역할")
+        void bondEtf_highRisk_shouldBeHedge() {
+            // given
+            Asset etf = assetRepository.findById(BOND_ETF_HIGH_RISK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(etf);
+
+            // then
+            assertThat(personality.getRole()).isEqualTo(Role.HEDGE);
+            assertThat(personality.getPersona()).isEqualTo(Persona.DEFENSIVE);
+        }
+
+        @Test
+        @DisplayName("COMMODITY ETF → HEDGE 역할, 방어형 페르소나")
+        void commodityEtf_shouldBeHedge() {
+            // given
+            Asset etf = assetRepository.findById(COMMODITY_ETF).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(etf);
+
+            // then
+            assertThat(personality.getRole()).isEqualTo(Role.HEDGE);
+            assertThat(personality.getExposureType()).isEqualTo(ExposureType.COMMODITY);
+            assertThat(personality.getPersona()).isEqualTo(Persona.DEFENSIVE);
+        }
+
+        @Test
+        @DisplayName("SECTOR ETF → SATELLITE 역할, 테마형 페르소나")
+        void sectorEtf_shouldBeSatellite() {
+            // given
+            Asset etf = assetRepository.findById(SECTOR_ETF).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(etf);
+
+            // then
+            assertThat(personality.getRole()).isEqualTo(Role.SATELLITE);
+            assertThat(personality.getExposureType()).isEqualTo(ExposureType.SECTOR);
+            assertThat(personality.getPersona()).isEqualTo(Persona.THEMATIC);
+        }
+    }
+
+    @Nested
+    @DisplayName("주식 성격 판별")
+    class StockPersonalityTest {
+
+        @Test
+        @DisplayName("고위험 주식 (risk >= 4) → GROWTH 역할, 공격형 페르소나")
+        void highRiskStock_shouldBeGrowth() {
+            // given
+            Asset stock = assetRepository.findById(HIGH_RISK_IT_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            assertThat(personality.getRole()).isEqualTo(Role.GROWTH);
+            assertThat(personality.getExposureType()).isEqualTo(ExposureType.SINGLE_STOCK);
+            assertThat(personality.getPersona()).isEqualTo(Persona.AGGRESSIVE);
+            assertThat(personality.getRiskLevel()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("중위험 주식 (risk = 3) → GROWTH 역할, 성장형 페르소나")
+        void midRiskStock_shouldBeGrowth() {
+            // given
+            Asset stock = assetRepository.findById(MID_RISK_IT_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            assertThat(personality.getRole()).isEqualTo(Role.GROWTH);
+            assertThat(personality.getPersona()).isEqualTo(Persona.GROWTH);
+            assertThat(personality.getRiskLevel()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("저위험 방어 섹터 주식 (배당 친화적) → DEFENSIVE 역할, DEFENSIVE 페르소나")
+        void lowRiskDefensiveSectorStock_shouldBeDefensive() {
+            // given: 배당 친화적 섹터 + 저위험 → DIVIDEND_FOCUSED → DEFENSIVE 역할
+            Asset stock = assetRepository.findById(LOW_RISK_HEALTHCARE_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            // 배당 친화적 섹터 + 저위험 → DIVIDEND_FOCUSED
+            // DIVIDEND_FOCUSED + 방어 섹터 → DEFENSIVE 역할
+            assertThat(personality.getRole()).isEqualTo(Role.DEFENSIVE);
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.DIVIDEND_FOCUSED);
+            assertThat(personality.getPersona()).isEqualTo(Persona.DEFENSIVE);
+        }
+
+        @Test
+        @DisplayName("저위험 일반 섹터 주식 → CORE 역할, BALANCED 페르소나")
+        void lowRiskNormalSectorStock_shouldBeCore() {
+            // given: IT 섹터는 배당 친화적이지 않음, 저위험 → HAS_DIVIDEND
+            Asset stock = assetRepository.findById(LOW_RISK_IT_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            // IT 섹터, risk 1 → HAS_DIVIDEND → CORE 역할
+            assertThat(personality.getRole()).isEqualTo(Role.CORE);
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.HAS_DIVIDEND);
+            // risk <= 2 + HAS_DIVIDEND → BALANCED
+            assertThat(personality.getPersona()).isEqualTo(Persona.BALANCED);
+        }
+    }
+
+    @Nested
+    @DisplayName("배당 프로필 판별")
+    class DividendProfileTest {
+
+        @Test
+        @DisplayName("배당 친화적 섹터 + 저위험 → DIVIDEND_FOCUSED")
+        void dividendFriendlySector_lowRisk_shouldBeDividendFocused() {
+            // given
+            Asset stock = assetRepository.findById(LOW_RISK_UTILITIES_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.DIVIDEND_FOCUSED);
+        }
+
+        @Test
+        @DisplayName("일반 섹터 + 저위험 → HAS_DIVIDEND")
+        void normalSector_lowRisk_shouldHaveDividend() {
+            // given
+            Asset stock = assetRepository.findById(LOW_RISK_IT_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.HAS_DIVIDEND);
+        }
+
+        @Test
+        @DisplayName("고위험 주식 → NONE")
+        void highRiskStock_shouldBeNone() {
+            // given
+            Asset stock = assetRepository.findById(HIGH_RISK_IT_STOCK_2).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.NONE);
+        }
+
+        @Test
+        @DisplayName("배당 데이터가 있는 경우 - HIGH_DIVIDEND → INCOME_CORE")
+        void withDividendData_highDividend_shouldBeIncomeCore() {
+            // given
+            Asset stock = assetRepository.findById(HIGH_DIVIDEND_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.INCOME_CORE);
+            assertThat(personality.getRole()).isEqualTo(Role.INCOME);
+        }
+
+        @Test
+        @DisplayName("배당 데이터가 있는 경우 - DIVIDEND_GROWTH → DIVIDEND_FOCUSED")
+        void withDividendData_dividendGrowth_shouldBeDividendFocused() {
+            // given
+            Asset stock = assetRepository.findById(DIVIDEND_GROWTH_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.DIVIDEND_FOCUSED);
+        }
+
+        @Test
+        @DisplayName("높은 배당수익률 + 월배당 → INCOME_CORE")
+        void highYield_monthlyDividend_shouldBeIncomeCore() {
+            // given
+            Asset stock = assetRepository.findById(MONTHLY_DIVIDEND_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.INCOME_CORE);
+        }
+    }
+
+    @Nested
+    @DisplayName("순차 계산 검증")
+    class SequentialCalculationTest {
+
+        @Test
+        @DisplayName("INCOME_CORE 배당 → INCOME 역할 → CASHFLOW 페르소나")
+        void incomeCoreLeadsToIncomeRole() {
+            // given
+            Asset stock = assetRepository.findById(INCOME_CORE_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.INCOME_CORE);
+            assertThat(personality.getRole()).isEqualTo(Role.INCOME);
+            assertThat(personality.getPersona()).isEqualTo(Persona.CASHFLOW);
+        }
+
+        @Test
+        @DisplayName("DIVIDEND_FOCUSED + 방어 섹터 → DEFENSIVE 역할")
+        void dividendFocusedDefensiveSectorLeadsToDefensive() {
+            // given
+            Asset stock = assetRepository.findById(LOW_RISK_UTILITIES_STOCK).orElseThrow();
+
+            // when
+            AssetPersonality personality = AssetPersonalityRuleEngine.compute(stock);
+
+            // then
+            assertThat(personality.getDividendProfile()).isEqualTo(DividendProfile.DIVIDEND_FOCUSED);
+            assertThat(personality.getRole()).isEqualTo(Role.DEFENSIVE);
+        }
+    }
+}

--- a/src/test/java/com/porcana/domain/portfolio/service/deck/DeckAnalysisEngineTest.java
+++ b/src/test/java/com/porcana/domain/portfolio/service/deck/DeckAnalysisEngineTest.java
@@ -218,22 +218,32 @@ class DeckAnalysisEngineTest extends BaseIntegrationTest {
         @DisplayName("균형형: 어떤 조건도 충족하지 않음")
         void balancedStyle() {
             // given: 균형 잡힌 포트폴리오 - 각 역할이 적절히 분산
-            // GROWTH < 50%, INCOME < 40%, DEFENSIVE+HEDGE < 40%, topSector < 50%
+            // GROWTH < 50%, INCOME < 40%, INCOME_CORE < 30%, DEFENSIVE+HEDGE < 40%, topSector < 50%
+            // Role 분류: JPM(risk=3, Financials)=GROWTH, MSFT(risk=2, IT)=CORE,
+            //           JNJ(risk=2, Healthcare)=DEFENSIVE, VYM(DIVIDEND ETF)=INCOME,
+            //           GLD(COMMODITY ETF)=HEDGE, NEE(risk=2, Utilities)=DEFENSIVE
             List<PositionWithAsset> positions = List.of(
-                    createPosition(AAPL, 20.0),   // GROWTH, IT
-                    createPosition(MSFT, 15.0),   // CORE (low risk IT)
-                    createPosition(JNJ, 15.0),    // DEFENSIVE, Healthcare
-                    createPosition(JPM, 15.0),    // CORE or GROWTH, Financials
-                    createPosition(VYM, 20.0),    // INCOME
-                    createPosition(GLD, 15.0)     // HEDGE
+                    createPosition(JPM, 30.0),    // GROWTH, Financials (risk=3)
+                    createPosition(MSFT, 25.0),   // CORE, IT (risk=2)
+                    createPosition(JNJ, 15.0),    // DEFENSIVE, Healthcare (risk=2)
+                    createPosition(VYM, 15.0),    // INCOME, Dividend ETF
+                    createPosition(GLD, 10.0),    // HEDGE, Commodity ETF
+                    createPosition(NEE, 5.0)      // DEFENSIVE, Utilities (risk=2)
             );
 
             // when
             DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
 
-            // then: 각 조건이 임계값 미만이면 BALANCED
-            // 실제 결과를 검증 (AGGRESSIVE, CASHFLOW, DEFENSIVE, GROWTH, THEMATIC 아닌 경우)
-            assertThat(analysis.getStyle()).isIn(DeckStyle.BALANCED, DeckStyle.GROWTH);
+            // then: 각 조건이 임계값 미만이어야 BALANCED
+            // - GROWTH(30%) < 50%
+            // - INCOME(15%) < 40%
+            // - DEFENSIVE(20%) + HEDGE(10%) = 30% < 40%
+            // - topSector(Financials 30%) < 50%
+            assertThat(analysis.getMetrics().getGrowthWeight()).isLessThan(50);
+            assertThat(analysis.getMetrics().getIncomeWeight()).isLessThan(40);
+            assertThat(analysis.getMetrics().getDefensiveWeight() + analysis.getMetrics().getHedgeWeight()).isLessThan(40);
+            assertThat(analysis.getMetrics().getTopSectorWeight()).isLessThan(50);
+            assertThat(analysis.getStyle()).isEqualTo(DeckStyle.BALANCED);
         }
     }
 

--- a/src/test/java/com/porcana/domain/portfolio/service/deck/DeckAnalysisEngineTest.java
+++ b/src/test/java/com/porcana/domain/portfolio/service/deck/DeckAnalysisEngineTest.java
@@ -1,0 +1,570 @@
+package com.porcana.domain.portfolio.service.deck;
+
+import com.porcana.BaseIntegrationTest;
+import com.porcana.domain.asset.dto.personality.AssetPersonality;
+import com.porcana.domain.asset.entity.Asset;
+import com.porcana.domain.asset.entity.Sector;
+import com.porcana.domain.asset.entity.personality.DividendProfile;
+import com.porcana.domain.asset.entity.personality.Role;
+import com.porcana.domain.asset.AssetRepository;
+import com.porcana.domain.asset.service.personality.AssetPersonalityRuleEngine;
+import com.porcana.domain.portfolio.dto.deck.DeckAnalysis;
+import com.porcana.domain.portfolio.dto.deck.PositionWithAsset;
+import com.porcana.domain.portfolio.entity.deck.DeckSignal;
+import com.porcana.domain.portfolio.entity.deck.DeckStyle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql(scripts = "/sql/deck-analysis-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class DeckAnalysisEngineTest extends BaseIntegrationTest {
+
+    @Autowired
+    private AssetRepository assetRepository;
+
+    // 고위험 성장 주식
+    private static final UUID NVDA = UUID.fromString("a0000000-0000-0000-0000-000000000001");
+    private static final UUID META = UUID.fromString("a0000000-0000-0000-0000-000000000002");
+    private static final UUID AAPL = UUID.fromString("a0000000-0000-0000-0000-000000000003");
+    private static final UUID MSFT = UUID.fromString("a0000000-0000-0000-0000-000000000004");
+
+    // CORE 역할 주식
+    private static final UUID JPM = UUID.fromString("b0000000-0000-0000-0000-000000000001");
+    private static final UUID JNJ = UUID.fromString("b0000000-0000-0000-0000-000000000002");
+    private static final UUID PG = UUID.fromString("b0000000-0000-0000-0000-000000000003");
+
+    // DEFENSIVE/HEDGE ETF
+    private static final UUID BND = UUID.fromString("c0000000-0000-0000-0000-000000000001");
+    private static final UUID GLD = UUID.fromString("c0000000-0000-0000-0000-000000000002");
+    private static final UUID TLT = UUID.fromString("c0000000-0000-0000-0000-000000000003");
+
+    // INCOME ETF
+    private static final UUID VYM = UUID.fromString("d0000000-0000-0000-0000-000000000001");
+    private static final UUID SCHD = UUID.fromString("d0000000-0000-0000-0000-000000000002");
+
+    // UTILITIES 주식
+    private static final UUID NEE = UUID.fromString("e0000000-0000-0000-0000-000000000001");
+    private static final UUID SO = UUID.fromString("e0000000-0000-0000-0000-000000000002");
+
+    // 한국 주식
+    private static final UUID SAMSUNG = UUID.fromString("f0000000-0000-0000-0000-000000000001");
+    private static final UUID SK_HYNIX = UUID.fromString("f0000000-0000-0000-0000-000000000002");
+    private static final UUID NAVER = UUID.fromString("f0000000-0000-0000-0000-000000000003");
+
+    // 배당 주식
+    private static final UUID O = UUID.fromString("01000000-0000-0000-0000-000000000001");
+    private static final UUID KO = UUID.fromString("01000000-0000-0000-0000-000000000002");
+    private static final UUID INTC = UUID.fromString("01000000-0000-0000-0000-000000000003");
+
+    // null 위험도 자산
+    private static final UUID NEWCO = UUID.fromString("02000000-0000-0000-0000-000000000001");
+
+    @Nested
+    @DisplayName("빈 포트폴리오 처리")
+    class EmptyPortfolioTest {
+
+        @Test
+        @DisplayName("null 포지션 → 빈 분석 결과")
+        void nullPositions_shouldReturnEmptyAnalysis() {
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(null);
+
+            // then
+            assertThat(analysis.getStyle()).isEqualTo(DeckStyle.BALANCED);
+            assertThat(analysis.getSignals()).isEmpty();
+            assertThat(analysis.getMetrics().getAssetCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("빈 포지션 리스트 → 빈 분석 결과")
+        void emptyPositions_shouldReturnEmptyAnalysis() {
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(List.of());
+
+            // then
+            assertThat(analysis.getStyle()).isEqualTo(DeckStyle.BALANCED);
+            assertThat(analysis.getSummary()).isEqualTo("포트폴리오에 자산이 없습니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("덱 스타일 판별")
+    class StyleDeterminationTest {
+
+        @Test
+        @DisplayName("공격형: 평균 위험도 4 이상 + 성장 비중 60% 이상")
+        void aggressiveStyle() {
+            // given: 고위험 성장 주식 중심
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(NVDA, 40.0),  // GROWTH, risk=5
+                    createPosition(META, 30.0),  // GROWTH, risk=4
+                    createPosition(JPM, 20.0),   // CORE, risk=3
+                    createPosition(NEE, 10.0)    // DEFENSIVE, risk=2
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getStyle()).isEqualTo(DeckStyle.AGGRESSIVE);
+            assertThat(analysis.getMetrics().getGrowthWeight()).isGreaterThanOrEqualTo(60);
+            assertThat(analysis.getMetrics().getWeightedAverageRisk()).isGreaterThanOrEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("현금흐름형: 인컴 비중 40% 이상")
+        void cashflowStyle() {
+            // given: 배당 ETF 중심
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(VYM, 45.0),   // INCOME
+                    createPosition(JPM, 35.0),   // CORE
+                    createPosition(AAPL, 20.0)   // GROWTH
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getStyle()).isEqualTo(DeckStyle.CASHFLOW);
+            assertThat(analysis.getMetrics().getIncomeWeight()).isGreaterThanOrEqualTo(40);
+        }
+
+        @Test
+        @DisplayName("현금흐름형: 인컴 코어 비중 30% 이상")
+        void cashflowStyle_byIncomeCoreWeight() {
+            // given: INCOME_CORE 배당 자산 35%
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(O, 35.0),     // INCOME_CORE 배당 프로필
+                    createPosition(JPM, 35.0),   // CORE
+                    createPosition(AAPL, 30.0)   // GROWTH
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getStyle()).isEqualTo(DeckStyle.CASHFLOW);
+            assertThat(analysis.getMetrics().getIncomeCoreWeight()).isGreaterThanOrEqualTo(30);
+        }
+
+        @Test
+        @DisplayName("방어형: 방어 + 헤지 비중 40% 이상")
+        void defensiveStyle() {
+            // given: 채권/헤지 자산 중심
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(BND, 30.0),   // DEFENSIVE
+                    createPosition(GLD, 20.0),   // HEDGE
+                    createPosition(PG, 30.0),    // CORE (Consumer Staples)
+                    createPosition(AAPL, 20.0)   // GROWTH
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getStyle()).isEqualTo(DeckStyle.DEFENSIVE);
+            // defensiveWeight + hedgeWeight >= 40
+            assertThat(analysis.getMetrics().getDefensiveWeight() + analysis.getMetrics().getHedgeWeight())
+                    .isGreaterThanOrEqualTo(40);
+        }
+
+        @Test
+        @DisplayName("성장형: 성장 비중 50% 이상 (공격형 조건 미충족)")
+        void growthStyle() {
+            // given: 성장 비중 55% 이지만 평균 위험도 4 미만
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(AAPL, 30.0),  // GROWTH, risk=3
+                    createPosition(META, 25.0),  // GROWTH, risk=4
+                    createPosition(JPM, 25.0),   // CORE
+                    createPosition(NEE, 20.0)    // DEFENSIVE
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then: GROWTH 55% (AAPL 30 + META 25), avg risk < 4
+            assertThat(analysis.getStyle()).isEqualTo(DeckStyle.GROWTH);
+            assertThat(analysis.getMetrics().getGrowthWeight()).isGreaterThanOrEqualTo(50);
+        }
+
+        @Test
+        @DisplayName("테마형: 최다 섹터 비중 50% 이상")
+        void thematicStyle() {
+            // given: IT 섹터 집중 55%
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(AAPL, 30.0),  // IT
+                    createPosition(MSFT, 25.0),  // IT
+                    createPosition(NEE, 25.0),   // Utilities
+                    createPosition(JPM, 20.0)    // Financials
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getStyle()).isEqualTo(DeckStyle.THEMATIC);
+            assertThat(analysis.getMetrics().getTopSector()).isEqualTo(Sector.INFORMATION_TECHNOLOGY);
+            assertThat(analysis.getMetrics().getTopSectorWeight()).isGreaterThanOrEqualTo(50);
+        }
+
+        @Test
+        @DisplayName("균형형: 어떤 조건도 충족하지 않음")
+        void balancedStyle() {
+            // given: 균형 잡힌 포트폴리오 - 각 역할이 적절히 분산
+            // GROWTH < 50%, INCOME < 40%, DEFENSIVE+HEDGE < 40%, topSector < 50%
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(AAPL, 20.0),   // GROWTH, IT
+                    createPosition(MSFT, 15.0),   // CORE (low risk IT)
+                    createPosition(JNJ, 15.0),    // DEFENSIVE, Healthcare
+                    createPosition(JPM, 15.0),    // CORE or GROWTH, Financials
+                    createPosition(VYM, 20.0),    // INCOME
+                    createPosition(GLD, 15.0)     // HEDGE
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then: 각 조건이 임계값 미만이면 BALANCED
+            // 실제 결과를 검증 (AGGRESSIVE, CASHFLOW, DEFENSIVE, GROWTH, THEMATIC 아닌 경우)
+            assertThat(analysis.getStyle()).isIn(DeckStyle.BALANCED, DeckStyle.GROWTH);
+        }
+    }
+
+    @Nested
+    @DisplayName("시그널 감지")
+    class SignalDetectionTest {
+
+        @Test
+        @DisplayName("섹터 집중: 최다 섹터 40% 이상")
+        void sectorConcentration() {
+            // given
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(AAPL, 45.0),  // IT
+                    createPosition(JNJ, 35.0),   // Healthcare
+                    createPosition(NEE, 20.0)    // Utilities
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getSignals()).contains(DeckSignal.SECTOR_CONCENTRATION);
+        }
+
+        @Test
+        @DisplayName("고위험 노출: 성장 60% 이상 + 평균 위험 4 이상")
+        void highRiskExposure() {
+            // given
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(NVDA, 40.0),  // GROWTH, risk=5
+                    createPosition(META, 30.0),  // GROWTH, risk=4
+                    createPosition(JPM, 30.0)    // CORE, risk=3
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getSignals()).contains(DeckSignal.HIGH_RISK_EXPOSURE);
+        }
+
+        @Test
+        @DisplayName("방어력 부족: 방어 + 헤지 비중 10% 이하")
+        void lowDefense() {
+            // given: 방어 자산 거의 없음
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(NVDA, 50.0),  // GROWTH
+                    createPosition(JPM, 30.0),   // CORE
+                    createPosition(VYM, 20.0)    // INCOME
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getSignals()).contains(DeckSignal.LOW_DEFENSE);
+        }
+
+        @Test
+        @DisplayName("종목 집중: 상위 3종목 55% 이상")
+        void highConcentration() {
+            // given: 7개 종목, 상위 3종목 60%
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(AAPL, 25.0),
+                    createPosition(JNJ, 20.0),
+                    createPosition(NEE, 15.0),
+                    createPosition(VYM, 10.0),
+                    createPosition(PG, 10.0),
+                    createPosition(GLD, 10.0),
+                    createPosition(JPM, 10.0)
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then: top3 = 25 + 20 + 15 = 60%
+            assertThat(analysis.getMetrics().getTop3Concentration()).isGreaterThanOrEqualTo(55);
+            assertThat(analysis.getSignals()).contains(DeckSignal.HIGH_CONCENTRATION);
+        }
+
+        @Test
+        @DisplayName("인컴 중심: 인컴 비중 40% 이상")
+        void highIncome() {
+            // given
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(VYM, 45.0),   // INCOME
+                    createPosition(JPM, 35.0),   // CORE
+                    createPosition(AAPL, 20.0)   // GROWTH
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getSignals()).contains(DeckSignal.HIGH_INCOME);
+        }
+
+        @Test
+        @DisplayName("시장 집중: 미국 90% 이상")
+        void marketConcentration() {
+            // given: 미국 시장 100%
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(AAPL, 50.0),  // US
+                    createPosition(JNJ, 50.0)    // US
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getMetrics().getUsWeight()).isGreaterThanOrEqualTo(90);
+            assertThat(analysis.getSignals()).contains(DeckSignal.MARKET_CONCENTRATION);
+        }
+
+        @Test
+        @DisplayName("시장 불균형: 미국 80% 이상 90% 미만")
+        void marketImbalance() {
+            // given: 미국 시장 85%
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(AAPL, 45.0),    // US
+                    createPosition(JNJ, 40.0),     // US
+                    createPosition(SAMSUNG, 15.0) // KR
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getMetrics().getUsWeight()).isGreaterThanOrEqualTo(80);
+            assertThat(analysis.getMetrics().getUsWeight()).isLessThan(90);
+            assertThat(analysis.getSignals()).contains(DeckSignal.MARKET_IMBALANCE);
+            assertThat(analysis.getSignals()).doesNotContain(DeckSignal.MARKET_CONCENTRATION);
+        }
+
+        @Test
+        @DisplayName("분산 부족: 5종목 미만 + 상위 3종목 60% 이상")
+        void lowDiversification() {
+            // given: 3개 종목만, top3 = 100%
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(AAPL, 40.0),
+                    createPosition(JNJ, 30.0),
+                    createPosition(NEE, 30.0)
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getMetrics().getAssetCount()).isLessThan(5);
+            assertThat(analysis.getMetrics().getTop3Concentration()).isGreaterThanOrEqualTo(60);
+            assertThat(analysis.getSignals()).contains(DeckSignal.LOW_DIVERSIFICATION);
+        }
+
+        @Test
+        @DisplayName("배당 성향: 배당 중심 종목 비중 25% 이상")
+        void dividendTilt() {
+            // given: DIVIDEND_FOCUSED 30%
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(KO, 30.0),    // DIVIDEND_FOCUSED
+                    createPosition(JPM, 40.0),   // CORE
+                    createPosition(AAPL, 30.0)   // GROWTH
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getMetrics().getDividendFocusedWeight()).isGreaterThanOrEqualTo(25);
+            assertThat(analysis.getSignals()).contains(DeckSignal.DIVIDEND_TILT);
+        }
+    }
+
+    @Nested
+    @DisplayName("지표 계산")
+    class MetricsCalculationTest {
+
+        @Test
+        @DisplayName("가중 평균 위험도 계산")
+        void weightedAverageRisk() {
+            // given
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(META, 50.0),  // risk=4
+                    createPosition(MSFT, 50.0)   // risk=2
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then: (4*50 + 2*50) / 100 = 3.0
+            assertThat(analysis.getMetrics().getWeightedAverageRisk()).isEqualTo(3.0);
+        }
+
+        @Test
+        @DisplayName("위험도가 null인 자산 제외하고 계산")
+        void weightedAverageRisk_excludeNullRisk() {
+            // given
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(META, 50.0),   // risk=4
+                    createPosition(NEWCO, 50.0)   // risk=null
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then: null 제외하고 (4*50) / 50 = 4.0
+            assertThat(analysis.getMetrics().getWeightedAverageRisk()).isEqualTo(4.0);
+        }
+
+        @Test
+        @DisplayName("ETF/주식 비중 계산")
+        void etfStockWeight() {
+            // given
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(VYM, 60.0),   // ETF
+                    createPosition(JNJ, 40.0)    // STOCK
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getMetrics().getEtfWeight()).isEqualTo(60.0);
+            assertThat(analysis.getMetrics().getStockWeight()).isEqualTo(40.0);
+        }
+
+        @Test
+        @DisplayName("미국/한국 비중 계산")
+        void usKrWeight() {
+            // given
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(AAPL, 70.0),    // US
+                    createPosition(SAMSUNG, 30.0) // KR
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getMetrics().getUsWeight()).isEqualTo(70.0);
+            assertThat(analysis.getMetrics().getKrWeight()).isEqualTo(30.0);
+        }
+
+        @Test
+        @DisplayName("배당 관련 비중 계산")
+        void dividendWeights() {
+            // given
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(O, 30.0),     // INCOME_CORE
+                    createPosition(KO, 25.0),    // DIVIDEND_FOCUSED
+                    createPosition(INTC, 20.0),  // HAS_DIVIDEND
+                    createPosition(AAPL, 25.0)   // NONE
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getMetrics().getIncomeCoreWeight()).isEqualTo(30.0);
+            assertThat(analysis.getMetrics().getDividendFocusedWeight()).isEqualTo(25.0);
+            // hasDividendWeight = INCOME_CORE + DIVIDEND_FOCUSED + HAS_DIVIDEND = 30 + 25 + 20 = 75
+            assertThat(analysis.getMetrics().getHasDividendWeight()).isEqualTo(75.0);
+        }
+
+        @Test
+        @DisplayName("헤지 비중 별도 계산")
+        void hedgeWeight() {
+            // given
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(GLD, 20.0),   // HEDGE
+                    createPosition(NEE, 30.0),   // DEFENSIVE
+                    createPosition(AAPL, 50.0)   // GROWTH
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getMetrics().getHedgeWeight()).isEqualTo(20.0);
+            assertThat(analysis.getMetrics().getDefensiveWeight()).isEqualTo(30.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("텍스트 해설 생성")
+    class TextGenerationTest {
+
+        @Test
+        @DisplayName("분석 결과에 텍스트 해설 포함")
+        void analysisIncludesText() {
+            // given
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(AAPL, 40.0),
+                    createPosition(JNJ, 30.0),
+                    createPosition(NEE, 30.0)
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then
+            assertThat(analysis.getSummary()).isNotBlank();
+            assertThat(analysis.getStrengths()).isNotEmpty();
+            assertThat(analysis.getWeaknesses()).isNotEmpty();
+            assertThat(analysis.getTips()).isNotEmpty();
+            assertThat(analysis.getInvestorFit()).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("배당 관련 해설 포함")
+        void dividendTextIncluded() {
+            // given: 인컴 코어 35% 이상
+            List<PositionWithAsset> positions = List.of(
+                    createPosition(O, 35.0),     // INCOME_CORE
+                    createPosition(JPM, 35.0),   // CORE
+                    createPosition(AAPL, 30.0)   // GROWTH
+            );
+
+            // when
+            DeckAnalysis analysis = DeckAnalysisEngine.analyze(positions);
+
+            // then: CASHFLOW 스타일이어야 함
+            assertThat(analysis.getStyle()).isEqualTo(DeckStyle.CASHFLOW);
+            assertThat(analysis.getSummary()).contains("배당");
+        }
+    }
+
+    // Helper methods
+
+    private PositionWithAsset createPosition(UUID assetId, Double weightPct) {
+        Asset asset = assetRepository.findById(assetId).orElseThrow();
+        AssetPersonality personality = AssetPersonalityRuleEngine.compute(asset);
+        return new PositionWithAsset(asset, weightPct, personality);
+    }
+}

--- a/src/test/resources/sql/deck-analysis-test-data.sql
+++ b/src/test/resources/sql/deck-analysis-test-data.sql
@@ -1,0 +1,85 @@
+-- Deck Analysis Engine 테스트용 데이터
+
+-- 기존 테스트 데이터 정리
+TRUNCATE TABLE asset_prices CASCADE;
+TRUNCATE TABLE assets CASCADE;
+
+-- ========== 스타일 판별용 자산 ==========
+
+-- 고위험 성장 주식 (GROWTH role용)
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES
+    ('a0000000-0000-0000-0000-000000000001', 'US', 'NVDA', 'NVIDIA Corporation', 'STOCK', 'INFORMATION_TECHNOLOGY', 5, true, CURRENT_DATE, NOW(), NOW()),
+    ('a0000000-0000-0000-0000-000000000002', 'US', 'META', 'Meta Platforms', 'STOCK', 'COMMUNICATION_SERVICES', 4, true, CURRENT_DATE, NOW(), NOW()),
+    ('a0000000-0000-0000-0000-000000000003', 'US', 'AAPL', 'Apple Inc.', 'STOCK', 'INFORMATION_TECHNOLOGY', 3, true, CURRENT_DATE, NOW(), NOW()),
+    ('a0000000-0000-0000-0000-000000000004', 'US', 'MSFT', 'Microsoft Corporation', 'STOCK', 'INFORMATION_TECHNOLOGY', 2, true, CURRENT_DATE, NOW(), NOW());
+
+-- CORE 역할용 주식
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES
+    ('b0000000-0000-0000-0000-000000000001', 'US', 'JPM', 'JPMorgan Chase', 'STOCK', 'FINANCIALS', 3, true, CURRENT_DATE, NOW(), NOW()),
+    ('b0000000-0000-0000-0000-000000000002', 'US', 'JNJ', 'Johnson & Johnson', 'STOCK', 'HEALTH_CARE', 2, true, CURRENT_DATE, NOW(), NOW()),
+    ('b0000000-0000-0000-0000-000000000003', 'US', 'PG', 'Procter & Gamble', 'STOCK', 'CONSUMER_STAPLES', 2, true, CURRENT_DATE, NOW(), NOW());
+
+-- DEFENSIVE/HEDGE 역할용 ETF
+INSERT INTO assets (id, market, symbol, name, type, asset_class, current_risk_level, active, as_of, created_at, updated_at)
+VALUES
+    ('c0000000-0000-0000-0000-000000000001', 'US', 'BND', 'Vanguard Total Bond Market ETF', 'ETF', 'BOND', 1, true, CURRENT_DATE, NOW(), NOW()),
+    ('c0000000-0000-0000-0000-000000000002', 'US', 'GLD', 'SPDR Gold Shares', 'ETF', 'COMMODITY', 2, true, CURRENT_DATE, NOW(), NOW()),
+    ('c0000000-0000-0000-0000-000000000003', 'US', 'TLT', 'iShares 20+ Year Treasury Bond ETF', 'ETF', 'BOND', 2, true, CURRENT_DATE, NOW(), NOW());
+
+-- INCOME 역할용 자산
+INSERT INTO assets (id, market, symbol, name, type, asset_class, current_risk_level, active, as_of,
+                    dividend_available, dividend_yield, dividend_category, dividend_frequency, dividend_data_status,
+                    created_at, updated_at)
+VALUES
+    ('d0000000-0000-0000-0000-000000000001', 'US', 'VYM', 'Vanguard High Dividend Yield ETF', 'ETF', 'DIVIDEND', 2, true, CURRENT_DATE,
+     true, 0.0350, 'HIGH_DIVIDEND', 'QUARTERLY', 'VERIFIED', NOW(), NOW()),
+    ('d0000000-0000-0000-0000-000000000002', 'US', 'SCHD', 'Schwab US Dividend Equity ETF', 'ETF', 'DIVIDEND', 2, true, CURRENT_DATE,
+     true, 0.0380, 'HIGH_DIVIDEND', 'QUARTERLY', 'VERIFIED', NOW(), NOW());
+
+-- UTILITIES 섹터 (DEFENSIVE 역할, 배당 친화적)
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES
+    ('e0000000-0000-0000-0000-000000000001', 'US', 'NEE', 'NextEra Energy', 'STOCK', 'UTILITIES', 2, true, CURRENT_DATE, NOW(), NOW()),
+    ('e0000000-0000-0000-0000-000000000002', 'US', 'SO', 'Southern Company', 'STOCK', 'UTILITIES', 2, true, CURRENT_DATE, NOW(), NOW());
+
+-- ========== 시장별 분산 테스트용 ==========
+
+-- 한국 시장 자산
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES
+    ('f0000000-0000-0000-0000-000000000001', 'KR', '005930', '삼성전자', 'STOCK', 'INFORMATION_TECHNOLOGY', 3, true, CURRENT_DATE, NOW(), NOW()),
+    ('f0000000-0000-0000-0000-000000000002', 'KR', '000660', 'SK하이닉스', 'STOCK', 'INFORMATION_TECHNOLOGY', 4, true, CURRENT_DATE, NOW(), NOW()),
+    ('f0000000-0000-0000-0000-000000000003', 'KR', '035420', 'NAVER', 'STOCK', 'COMMUNICATION_SERVICES', 3, true, CURRENT_DATE, NOW(), NOW());
+
+-- ========== 배당 관련 테스트용 ==========
+
+-- INCOME_CORE 배당 프로필용
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of,
+                    dividend_available, dividend_yield, dividend_category, dividend_frequency, dividend_data_status,
+                    created_at, updated_at)
+VALUES
+    ('01000000-0000-0000-0000-000000000001', 'US', 'O', 'Realty Income Corp', 'STOCK', 'REAL_ESTATE', 2, true, CURRENT_DATE,
+     true, 0.0550, 'HIGH_DIVIDEND', 'MONTHLY', 'VERIFIED', NOW(), NOW());
+
+-- DIVIDEND_FOCUSED 배당 프로필용
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of,
+                    dividend_available, dividend_yield, dividend_category, dividend_frequency, dividend_data_status,
+                    created_at, updated_at)
+VALUES
+    ('01000000-0000-0000-0000-000000000002', 'US', 'KO', 'Coca-Cola Company', 'STOCK', 'CONSUMER_STAPLES', 2, true, CURRENT_DATE,
+     true, 0.0280, 'DIVIDEND_GROWTH', 'QUARTERLY', 'VERIFIED', NOW(), NOW());
+
+-- HAS_DIVIDEND 배당 프로필용
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of,
+                    dividend_available, dividend_yield, dividend_category, dividend_frequency, dividend_data_status,
+                    created_at, updated_at)
+VALUES
+    ('01000000-0000-0000-0000-000000000003', 'US', 'INTC', 'Intel Corporation', 'STOCK', 'INFORMATION_TECHNOLOGY', 3, true, CURRENT_DATE,
+     true, 0.0150, 'HAS_DIVIDEND', 'QUARTERLY', 'VERIFIED', NOW(), NOW());
+
+-- ========== null 위험도 테스트용 ==========
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES
+    ('02000000-0000-0000-0000-000000000001', 'US', 'NEWCO', 'New Company Inc.', 'STOCK', 'INFORMATION_TECHNOLOGY', NULL, true, CURRENT_DATE, NOW(), NOW());

--- a/src/test/resources/sql/personality-test-data.sql
+++ b/src/test/resources/sql/personality-test-data.sql
@@ -1,0 +1,91 @@
+-- Asset Personality Rule Engine 테스트용 데이터
+
+-- 기존 테스트 데이터 정리
+TRUNCATE TABLE asset_prices CASCADE;
+TRUNCATE TABLE assets CASCADE;
+
+-- ========== ETF 테스트 데이터 ==========
+
+-- EQUITY_INDEX ETF (저위험, risk=2)
+INSERT INTO assets (id, market, symbol, name, type, asset_class, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('10000000-0000-0000-0000-000000000001', 'US', 'SPY', 'SPDR S&P 500 ETF', 'ETF', 'EQUITY_INDEX', 2, true, CURRENT_DATE, NOW(), NOW());
+
+-- EQUITY_INDEX ETF (중위험, risk=3)
+INSERT INTO assets (id, market, symbol, name, type, asset_class, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('10000000-0000-0000-0000-000000000002', 'US', 'QQQ', 'Invesco QQQ Trust', 'ETF', 'EQUITY_INDEX', 3, true, CURRENT_DATE, NOW(), NOW());
+
+-- DIVIDEND ETF (저위험, risk=2)
+INSERT INTO assets (id, market, symbol, name, type, asset_class, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('10000000-0000-0000-0000-000000000003', 'US', 'VYM', 'Vanguard High Dividend Yield ETF', 'ETF', 'DIVIDEND', 2, true, CURRENT_DATE, NOW(), NOW());
+
+-- BOND ETF (저위험, risk=1)
+INSERT INTO assets (id, market, symbol, name, type, asset_class, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('10000000-0000-0000-0000-000000000004', 'US', 'BND', 'Vanguard Total Bond Market ETF', 'ETF', 'BOND', 1, true, CURRENT_DATE, NOW(), NOW());
+
+-- BOND ETF (고위험, risk=4)
+INSERT INTO assets (id, market, symbol, name, type, asset_class, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('10000000-0000-0000-0000-000000000005', 'US', 'HYG', 'iShares iBoxx High Yield Corp Bond ETF', 'ETF', 'BOND', 4, true, CURRENT_DATE, NOW(), NOW());
+
+-- COMMODITY ETF (중위험, risk=3)
+INSERT INTO assets (id, market, symbol, name, type, asset_class, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('10000000-0000-0000-0000-000000000006', 'US', 'GLD', 'SPDR Gold Shares', 'ETF', 'COMMODITY', 3, true, CURRENT_DATE, NOW(), NOW());
+
+-- SECTOR ETF (중위험, risk=3)
+INSERT INTO assets (id, market, symbol, name, type, asset_class, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('10000000-0000-0000-0000-000000000007', 'US', 'XLK', 'Technology Select Sector SPDR', 'ETF', 'SECTOR', 3, true, CURRENT_DATE, NOW(), NOW());
+
+-- ========== 주식 테스트 데이터 ==========
+
+-- 고위험 IT 주식 (risk=5)
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('20000000-0000-0000-0000-000000000001', 'US', 'NVDA', 'NVIDIA Corporation', 'STOCK', 'INFORMATION_TECHNOLOGY', 5, true, CURRENT_DATE, NOW(), NOW());
+
+-- 중위험 IT 주식 (risk=3)
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('20000000-0000-0000-0000-000000000002', 'US', 'AAPL', 'Apple Inc.', 'STOCK', 'INFORMATION_TECHNOLOGY', 3, true, CURRENT_DATE, NOW(), NOW());
+
+-- 저위험 방어 섹터 주식 - Healthcare (risk=2) - 배당 친화적 섹터
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('20000000-0000-0000-0000-000000000003', 'US', 'JNJ', 'Johnson & Johnson', 'STOCK', 'HEALTH_CARE', 2, true, CURRENT_DATE, NOW(), NOW());
+
+-- 저위험 일반 섹터 주식 - IT (risk=1)
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('20000000-0000-0000-0000-000000000004', 'US', 'MSFT', 'Microsoft Corporation', 'STOCK', 'INFORMATION_TECHNOLOGY', 1, true, CURRENT_DATE, NOW(), NOW());
+
+-- 배당 친화적 섹터 + 저위험 - Utilities (risk=2)
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('20000000-0000-0000-0000-000000000005', 'US', 'NEE', 'NextEra Energy', 'STOCK', 'UTILITIES', 2, true, CURRENT_DATE, NOW(), NOW());
+
+-- 고위험 IT 주식 (risk=4) - 배당 프로필 NONE 테스트용
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
+VALUES ('20000000-0000-0000-0000-000000000006', 'US', 'TSLA', 'Tesla Inc.', 'STOCK', 'INFORMATION_TECHNOLOGY', 4, true, CURRENT_DATE, NOW(), NOW());
+
+-- ========== 배당 데이터가 있는 주식 ==========
+
+-- HIGH_DIVIDEND + VERIFIED - Financials (risk=2)
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of,
+                    dividend_available, dividend_yield, dividend_category, dividend_frequency, dividend_data_status,
+                    created_at, updated_at)
+VALUES ('30000000-0000-0000-0000-000000000001', 'US', 'JPM', 'JPMorgan Chase', 'STOCK', 'FINANCIALS', 2, true, CURRENT_DATE,
+        true, 0.0500, 'HIGH_DIVIDEND', 'QUARTERLY', 'VERIFIED', NOW(), NOW());
+
+-- DIVIDEND_GROWTH + VERIFIED - Consumer Staples (risk=2)
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of,
+                    dividend_available, dividend_yield, dividend_category, dividend_frequency, dividend_data_status,
+                    created_at, updated_at)
+VALUES ('30000000-0000-0000-0000-000000000002', 'US', 'PG', 'Procter & Gamble', 'STOCK', 'CONSUMER_STAPLES', 2, true, CURRENT_DATE,
+        true, 0.0250, 'DIVIDEND_GROWTH', 'QUARTERLY', 'VERIFIED', NOW(), NOW());
+
+-- 높은 배당수익률 + 월배당 - Real Estate (risk=2)
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of,
+                    dividend_available, dividend_yield, dividend_category, dividend_frequency, dividend_data_status,
+                    created_at, updated_at)
+VALUES ('30000000-0000-0000-0000-000000000003', 'US', 'O', 'Realty Income Corp', 'STOCK', 'REAL_ESTATE', 2, true, CURRENT_DATE,
+        true, 0.0450, 'HAS_DIVIDEND', 'MONTHLY', 'VERIFIED', NOW(), NOW());
+
+-- HIGH_DIVIDEND + VERIFIED - Utilities (risk=2) - INCOME_CORE 테스트용
+INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of,
+                    dividend_available, dividend_yield, dividend_category, dividend_frequency, dividend_data_status,
+                    created_at, updated_at)
+VALUES ('30000000-0000-0000-0000-000000000004', 'US', 'SO', 'Southern Company', 'STOCK', 'UTILITIES', 2, true, CURRENT_DATE,
+        true, 0.0600, 'HIGH_DIVIDEND', 'QUARTERLY', 'VERIFIED', NOW(), NOW());


### PR DESCRIPTION
## Summary
- 배당 데이터 도메인 모델 추가 (DividendFrequency, DividendCategory, DividendDataStatus)
- AssetPersonality 시스템 구현 (Role, ExposureType, Persona, DividendProfile)
- DeckAnalysisEngine + DeckTextTemplate으로 포트폴리오 분석 기능 구현
- `/portfolios/{id}/deck-analysis` API 엔드포인트 추가
- 입력 검증 및 안정성 강화

## Test plan
- [x] AssetPersonalityRuleEngineTest - 17개 케이스 (ETF/주식 성격 판별)
- [x] DeckAnalysisEngineTest - 23개 케이스 (스타일/시그널 감지)
- [x] SQL 기반 통합 테스트 데이터

## Changes
| Commit | Description |
|--------|-------------|
| `d6b3390` | 배당 관련 Enum 추가 |
| `cb9baff` | Asset 엔티티에 배당 필드 추가 |
| `3fc84a0` | AssetPersonality 도메인 Enum 추가 |
| `a002a12` | AssetPersonality 시스템 구현 |
| `b591e77` | Deck 분석 도메인 모델 추가 |
| `2e6ae3f` | DeckAnalysisEngine + DeckTextTemplate 구현 |
| `a388c35` | Deck 분석 API 엔드포인트 추가 |
| `53853ac` | SQL 기반 통합 테스트 추가 |
| `4425cdd` | 입력 검증 및 안정성 강화 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 자산 성격 프로필 추가(역할·페르소나·노출유형·배당프로필) 및 자산 상세에 포함(이미지·현재 리스크 개선)
  * 포트폴리오 덱 분석 추가(스타일·지표·신호·한글 설명 텍스트) 및 신규 API 엔드포인트 제공
  * 외부 배당 데이터 수집 지원 및 배당 데이터 자동 업데이트 실행기 추가(가용성·수익률·빈도·카테고리·상태)

* **문서**
  * API 응답/모델에 OpenAPI/Swagger 설명 추가

* **테스트**
  * 성격 분류 규칙 엔진 및 덱 분석 엔진 통합 테스트와 테스트 데이터 추가

* **DB 마이그레이션**
  * 자산 테이블에 배당 관련 컬럼·인덱스·컬럼 설명 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->