### PR TITLE
Feat: 비중 수정 시 baseline 목표 비중 반영 옵션 추가

### DIFF
--- a/src/main/java/com/porcana/domain/portfolio/command/UpdateAssetWeightsCommand.java
+++ b/src/main/java/com/porcana/domain/portfolio/command/UpdateAssetWeightsCommand.java
@@ -15,6 +15,7 @@ public class UpdateAssetWeightsCommand {
     private final UUID portfolioId;
     private final UUID userId;
     private final List<AssetWeightUpdate> weights;
+    private final boolean applyToBaseline;
 
     @Getter
     @Builder
@@ -35,6 +36,7 @@ public class UpdateAssetWeightsCommand {
                 .portfolioId(portfolioId)
                 .userId(userId)
                 .weights(weights)
+                .applyToBaseline(Boolean.TRUE.equals(request.applyToBaseline()))
                 .build();
     }
 }

--- a/src/main/java/com/porcana/domain/portfolio/dto/UpdateAssetWeightsRequest.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/UpdateAssetWeightsRequest.java
@@ -9,7 +9,13 @@ import java.util.List;
 public record UpdateAssetWeightsRequest(
         @NotEmpty(message = "자산 비중 목록은 비어있을 수 없습니다")
         @Valid
-        List<AssetWeight> weights
+        List<AssetWeight> weights,
+
+        /**
+         * true: baseline의 targetWeightPct도 함께 업데이트
+         * false 또는 null: baseline 변경 없음 (기본값)
+         */
+        Boolean applyToBaseline
 ) {
     public record AssetWeight(
             @NotNull(message = "자산 ID는 필수입니다")

--- a/src/main/java/com/porcana/domain/portfolio/entity/PortfolioHoldingBaselineItem.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/PortfolioHoldingBaselineItem.java
@@ -123,4 +123,20 @@ public class PortfolioHoldingBaselineItem {
         this.avgPrice = totalCost.divide(newQuantity, 4, java.math.RoundingMode.HALF_UP);
         this.quantity = newQuantity;
     }
+
+    /**
+     * 목표 비중 업데이트
+     * 포트폴리오 비중 수정 시 baseline에도 반영할 때 사용
+     *
+     * @param newTargetWeightPct 새로운 목표 비중 (0~100)
+     */
+    public void updateTargetWeight(BigDecimal newTargetWeightPct) {
+        if (newTargetWeightPct == null) {
+            throw new IllegalArgumentException("targetWeightPct must not be null");
+        }
+        if (newTargetWeightPct.compareTo(BigDecimal.ZERO) < 0 || newTargetWeightPct.compareTo(new BigDecimal("100")) > 0) {
+            throw new IllegalArgumentException("targetWeightPct must be between 0 and 100");
+        }
+        this.targetWeightPct = newTargetWeightPct;
+    }
 }

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -40,6 +40,7 @@ public class PortfolioService {
     private final SnapshotAssetDailyReturnRepository snapshotAssetDailyReturnRepository;
     private final PortfolioSnapshotRepository portfolioSnapshotRepository;
     private final PortfolioSnapshotAssetRepository portfolioSnapshotAssetRepository;
+    private final PortfolioHoldingBaselineRepository holdingBaselineRepository;
 
     private static final int MAX_GUEST_PORTFOLIOS = 3;
 
@@ -733,6 +734,23 @@ public class PortfolioService {
                 today,
                 "Portfolio rebalancing"
         );
+
+        // baseline에도 목표 비중 반영
+        if (command.isApplyToBaseline()) {
+            holdingBaselineRepository.findByPortfolioIdWithItems(command.getPortfolioId())
+                    .ifPresent(baseline -> {
+                        Map<UUID, PortfolioHoldingBaselineItem> baselineItemMap = baseline.getItems().stream()
+                                .collect(Collectors.toMap(PortfolioHoldingBaselineItem::getAssetId, item -> item));
+
+                        for (UpdateAssetWeightsCommand.AssetWeightUpdate weightUpdate : command.getWeights()) {
+                            PortfolioHoldingBaselineItem item = baselineItemMap.get(weightUpdate.getAssetId());
+                            if (item != null) {
+                                item.updateTargetWeight(weightUpdate.getWeightPct());
+                            }
+                        }
+                        holdingBaselineRepository.save(baseline);
+                    });
+        }
 
         return UpdateAssetWeightsResponse.from(portfolio, updatedWeights);
     }

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -744,9 +744,13 @@ public class PortfolioService {
 
                         for (UpdateAssetWeightsCommand.AssetWeightUpdate weightUpdate : command.getWeights()) {
                             PortfolioHoldingBaselineItem item = baselineItemMap.get(weightUpdate.getAssetId());
-                            if (item != null) {
-                                item.updateTargetWeight(weightUpdate.getWeightPct());
+                            if (item == null) {
+                                throw new IllegalArgumentException(
+                                        "Baseline item not found for asset: " + weightUpdate.getAssetId()
+                                );
                             }
+                            item.updateTargetWeight(weightUpdate.getWeightPct());
+
                         }
                         holdingBaselineRepository.save(baseline);
                     });

--- a/src/test/java/com/porcana/domain/portfolio/HoldingBaselineControllerTest.java
+++ b/src/test/java/com/porcana/domain/portfolio/HoldingBaselineControllerTest.java
@@ -1,6 +1,7 @@
 package com.porcana.domain.portfolio;
 
 import com.porcana.BaseIntegrationTest;
+import com.porcana.domain.portfolio.dto.UpdateAssetWeightsRequest;
 import com.porcana.domain.portfolio.dto.baseline.ExecuteTopUpRequest;
 import com.porcana.domain.portfolio.dto.baseline.RebalancingPlanRequest;
 import com.porcana.domain.portfolio.dto.baseline.SetSeedRequest;
@@ -829,6 +830,270 @@ class HoldingBaselineControllerTest extends BaseIntegrationTest {
                     .log().all()
                     .statusCode(200)
                     .body("thresholdPct", equalTo(5.0f));
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /portfolios/{portfolioId}/weights - applyToBaseline 옵션 테스트")
+    class ApplyToBaselineTest {
+
+        @Test
+        @DisplayName("성공 - applyToBaseline=true 시 baseline targetWeightPct 업데이트")
+        void updateWeights_applyToBaseline_true() {
+            String accessToken = createAccessToken();
+
+            // 1. 먼저 시드 설정 (baseline 생성)
+            SetSeedRequest setSeedRequest = new SetSeedRequest(new BigDecimal("10000000"), "KRW");
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(setSeedRequest)
+            .when()
+                    .put("/portfolios/{portfolioId}/seed", TEST_PORTFOLIO_ID)
+            .then()
+                    .statusCode(200);
+
+            // 2. 초기 baseline 상태 확인 (50/50)
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+            .when()
+                    .get("/portfolios/{portfolioId}/holding-baseline", TEST_PORTFOLIO_ID)
+            .then()
+                    .statusCode(200)
+                    .body("items.find { it.symbol == 'BASELINE_KR' }.targetWeightPct", equalTo(50.0f))
+                    .body("items.find { it.symbol == 'BASELINE_US' }.targetWeightPct", equalTo(50.0f));
+
+            // 3. applyToBaseline=true로 비중 수정 (70/30)
+            UpdateAssetWeightsRequest request = new UpdateAssetWeightsRequest(
+                    List.of(
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
+                    ),
+                    true  // applyToBaseline = true
+            );
+
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .put("/portfolios/{portfolioId}/weights", TEST_PORTFOLIO_ID)
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("weights", hasSize(2));
+
+            // 4. baseline의 targetWeightPct가 70/30으로 변경되었는지 확인
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+            .when()
+                    .get("/portfolios/{portfolioId}/holding-baseline", TEST_PORTFOLIO_ID)
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("items.find { it.symbol == 'BASELINE_KR' }.targetWeightPct", equalTo(70.0f))
+                    .body("items.find { it.symbol == 'BASELINE_US' }.targetWeightPct", equalTo(30.0f));
+        }
+
+        @Test
+        @DisplayName("성공 - applyToBaseline=false 시 baseline targetWeightPct 유지")
+        void updateWeights_applyToBaseline_false() {
+            String accessToken = createAccessToken();
+
+            // 1. 먼저 시드 설정 (baseline 생성)
+            SetSeedRequest setSeedRequest = new SetSeedRequest(new BigDecimal("10000000"), "KRW");
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(setSeedRequest)
+            .when()
+                    .put("/portfolios/{portfolioId}/seed", TEST_PORTFOLIO_ID)
+            .then()
+                    .statusCode(200);
+
+            // 2. 초기 baseline 상태 확인 (50/50)
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+            .when()
+                    .get("/portfolios/{portfolioId}/holding-baseline", TEST_PORTFOLIO_ID)
+            .then()
+                    .statusCode(200)
+                    .body("items.find { it.symbol == 'BASELINE_KR' }.targetWeightPct", equalTo(50.0f))
+                    .body("items.find { it.symbol == 'BASELINE_US' }.targetWeightPct", equalTo(50.0f));
+
+            // 3. applyToBaseline=false로 비중 수정 (70/30)
+            UpdateAssetWeightsRequest request = new UpdateAssetWeightsRequest(
+                    List.of(
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
+                    ),
+                    false  // applyToBaseline = false
+            );
+
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .put("/portfolios/{portfolioId}/weights", TEST_PORTFOLIO_ID)
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("weights", hasSize(2));
+
+            // 4. baseline의 targetWeightPct가 여전히 50/50인지 확인
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+            .when()
+                    .get("/portfolios/{portfolioId}/holding-baseline", TEST_PORTFOLIO_ID)
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("items.find { it.symbol == 'BASELINE_KR' }.targetWeightPct", equalTo(50.0f))
+                    .body("items.find { it.symbol == 'BASELINE_US' }.targetWeightPct", equalTo(50.0f));
+        }
+
+        @Test
+        @DisplayName("성공 - applyToBaseline=null (기본값) 시 baseline targetWeightPct 유지")
+        void updateWeights_applyToBaseline_null() {
+            String accessToken = createAccessToken();
+
+            // 1. 먼저 시드 설정 (baseline 생성)
+            SetSeedRequest setSeedRequest = new SetSeedRequest(new BigDecimal("10000000"), "KRW");
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(setSeedRequest)
+            .when()
+                    .put("/portfolios/{portfolioId}/seed", TEST_PORTFOLIO_ID)
+            .then()
+                    .statusCode(200);
+
+            // 2. 초기 baseline 상태 확인 (50/50)
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+            .when()
+                    .get("/portfolios/{portfolioId}/holding-baseline", TEST_PORTFOLIO_ID)
+            .then()
+                    .statusCode(200)
+                    .body("items.find { it.symbol == 'BASELINE_KR' }.targetWeightPct", equalTo(50.0f))
+                    .body("items.find { it.symbol == 'BASELINE_US' }.targetWeightPct", equalTo(50.0f));
+
+            // 3. applyToBaseline=null로 비중 수정 (70/30)
+            UpdateAssetWeightsRequest request = new UpdateAssetWeightsRequest(
+                    List.of(
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
+                    ),
+                    null  // applyToBaseline = null (기본값)
+            );
+
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .put("/portfolios/{portfolioId}/weights", TEST_PORTFOLIO_ID)
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("weights", hasSize(2));
+
+            // 4. baseline의 targetWeightPct가 여전히 50/50인지 확인
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+            .when()
+                    .get("/portfolios/{portfolioId}/holding-baseline", TEST_PORTFOLIO_ID)
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("items.find { it.symbol == 'BASELINE_KR' }.targetWeightPct", equalTo(50.0f))
+                    .body("items.find { it.symbol == 'BASELINE_US' }.targetWeightPct", equalTo(50.0f));
+        }
+
+        @Test
+        @DisplayName("성공 - baseline 없이 applyToBaseline=true 요청 시 정상 처리 (무시)")
+        void updateWeights_applyToBaseline_true_noBaseline() {
+            String accessToken = createAccessToken();
+
+            // baseline 설정 없이 바로 비중 수정 (applyToBaseline=true)
+            UpdateAssetWeightsRequest request = new UpdateAssetWeightsRequest(
+                    List.of(
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
+                    ),
+                    true  // applyToBaseline = true
+            );
+
+            // baseline이 없어도 에러 없이 정상 처리되어야 함
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .put("/portfolios/{portfolioId}/weights", TEST_PORTFOLIO_ID)
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("weights", hasSize(2))
+                    .body("weights[0].weightPct", anyOf(equalTo(70.0f), equalTo(30.0f)))
+                    .body("weights[1].weightPct", anyOf(equalTo(70.0f), equalTo(30.0f)));
+
+            // baseline이 여전히 없는지 확인
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+            .when()
+                    .get("/portfolios/{portfolioId}/holding-baseline", TEST_PORTFOLIO_ID)
+            .then()
+                    .statusCode(200)
+                    .body("exists", equalTo(false));
+        }
+
+        @Test
+        @DisplayName("성공 - applyToBaseline=true 후 리밸런싱 상태에서 새 목표 비중 반영 확인")
+        void updateWeights_applyToBaseline_true_verifyInRebalanceStatus() {
+            String accessToken = createAccessToken();
+
+            // 1. 시드 설정 (baseline 생성)
+            SetSeedRequest setSeedRequest = new SetSeedRequest(new BigDecimal("10000000"), "KRW");
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(setSeedRequest)
+            .when()
+                    .put("/portfolios/{portfolioId}/seed", TEST_PORTFOLIO_ID)
+            .then()
+                    .statusCode(200);
+
+            // 2. applyToBaseline=true로 비중 수정 (70/30)
+            UpdateAssetWeightsRequest request = new UpdateAssetWeightsRequest(
+                    List.of(
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
+                    ),
+                    true
+            );
+
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .put("/portfolios/{portfolioId}/weights", TEST_PORTFOLIO_ID)
+            .then()
+                    .statusCode(200);
+
+            // 3. 리밸런싱 상태 조회에서 새 목표 비중(70/30) 반영 확인
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+            .when()
+                    .get("/portfolios/{portfolioId}/rebalance-status", TEST_PORTFOLIO_ID)
+            .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body("hasBaseline", equalTo(true))
+                    .body("items.find { it.symbol == 'BASELINE_KR' }.targetWeightPct", equalTo(70.0f))
+                    .body("items.find { it.symbol == 'BASELINE_US' }.targetWeightPct", equalTo(30.0f));
         }
     }
 }

--- a/src/test/java/com/porcana/domain/portfolio/HoldingBaselineControllerTest.java
+++ b/src/test/java/com/porcana/domain/portfolio/HoldingBaselineControllerTest.java
@@ -1036,8 +1036,11 @@ class HoldingBaselineControllerTest extends BaseIntegrationTest {
                     .log().all()
                     .statusCode(200)
                     .body("weights", hasSize(2))
-                    .body("weights[0].weightPct", anyOf(equalTo(70.0f), equalTo(30.0f)))
-                    .body("weights[1].weightPct", anyOf(equalTo(70.0f), equalTo(30.0f)));
+                    .body("weights.assetId", containsInAnyOrder(
+                            TEST_ASSET_KR_ID.toString(),
+                            TEST_ASSET_US_ID.toString()
+                    ))
+                    .body("weights.weightPct", containsInAnyOrder(70.0f, 30.0f));
 
             // baseline이 여전히 없는지 확인
             given()
@@ -1094,6 +1097,45 @@ class HoldingBaselineControllerTest extends BaseIntegrationTest {
                     .body("hasBaseline", equalTo(true))
                     .body("items.find { it.symbol == 'BASELINE_KR' }.targetWeightPct", equalTo(70.0f))
                     .body("items.find { it.symbol == 'BASELINE_US' }.targetWeightPct", equalTo(30.0f));
+        }
+
+        @Test
+        @DisplayName("실패 - applyToBaseline=true 시 baseline에 없는 자산 포함하면 예외 발생")
+        void updateWeights_applyToBaseline_true_assetNotInBaseline_shouldFail() {
+            String accessToken = createAccessToken();
+
+            // 1. 시드 설정 (baseline 생성 - KR, US 두 자산만 포함)
+            SetSeedRequest setSeedRequest = new SetSeedRequest(new BigDecimal("10000000"), "KRW");
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(setSeedRequest)
+            .when()
+                    .put("/portfolios/{portfolioId}/seed", TEST_PORTFOLIO_ID)
+            .then()
+                    .statusCode(200);
+
+            // 2. baseline에 존재하지 않는 자산 ID로 비중 수정 시도
+            UUID nonExistentAssetId = UUID.fromString("99999999-9999-9999-9999-999999999999");
+            UpdateAssetWeightsRequest request = new UpdateAssetWeightsRequest(
+                    List.of(
+                            new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 50.00),
+                            new UpdateAssetWeightsRequest.AssetWeight(nonExistentAssetId.toString(), 50.00)
+                    ),
+                    true  // applyToBaseline = true
+            );
+
+            // 3. baseline에 없는 자산이 포함되어 있으므로 400 에러 발생
+            given()
+                    .header("Authorization", "Bearer " + accessToken)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+            .when()
+                    .put("/portfolios/{portfolioId}/weights", TEST_PORTFOLIO_ID)
+            .then()
+                    .log().all()
+                    .statusCode(400)
+                    .body("message", containsString("not found"));
         }
     }
 }

--- a/src/test/java/com/porcana/domain/portfolio/PortfolioControllerTest.java
+++ b/src/test/java/com/porcana/domain/portfolio/PortfolioControllerTest.java
@@ -93,7 +93,8 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 List.of(
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
-                )
+                ),
+                null
         );
 
         given()
@@ -121,7 +122,8 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 List.of(
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
-                )
+                ),
+                null
         );
 
         given()
@@ -138,7 +140,8 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 List.of(
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 60.00),
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 40.00)
-                )
+                ),
+                null
         );
 
         given()
@@ -164,7 +167,8 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 List.of(
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 50.00),
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 40.00)
-                )
+                ),
+                null
         );
 
         given()
@@ -189,7 +193,8 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 List.of(
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 50.00),
                         new UpdateAssetWeightsRequest.AssetWeight(nonExistentAssetId, 50.00)
-                )
+                ),
+                null
         );
 
         given()
@@ -209,7 +214,8 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 List.of(
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
-                )
+                ),
+                null
         );
 
         given()
@@ -231,7 +237,8 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 List.of(
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
-                )
+                ),
+                null
         );
 
         given()
@@ -267,7 +274,8 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 List.of(
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
-                )
+                ),
+                null
         );
 
         given()
@@ -359,7 +367,8 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 List.of(
                         new UpdateAssetWeightsRequest.AssetWeight(testAssetKrId.toString(), 70.00),
                         new UpdateAssetWeightsRequest.AssetWeight(testAssetUsId.toString(), 30.00)
-                )
+                ),
+                null
         );
 
         given()
@@ -588,7 +597,8 @@ class PortfolioControllerTest extends BaseIntegrationTest {
                 List.of(
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_KR_ID.toString(), 70.00),
                         new UpdateAssetWeightsRequest.AssetWeight(TEST_ASSET_US_ID.toString(), 30.00)
-                )
+                ),
+                null
         );
 
         given()


### PR DESCRIPTION
## Summary
- `PUT /portfolios/{portfolioId}/weights` API에 `applyToBaseline` 필드 추가
- `applyToBaseline=true`일 때 baseline의 `targetWeightPct`도 함께 업데이트
- 리밸런싱 후 baseline 목표 비중이 변경되지 않는 문제 해결

## API 변경
```json
PUT /api/v1/portfolios/{portfolioId}/weights
{
  "weights": [
    { "assetId": "...", "weightPct": 70.0 },
    { "assetId": "...", "weightPct": 30.0 }
  ],
  "applyToBaseline": true  // 새 필드 (optional, default: false)
}
```

## Test plan
- [x] 기존 비중 수정 테스트 통과 확인
- [x] applyToBaseline=null일 때 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 자산 가중치 업데이트 시 기준선(target weight)을 함께 변경할 수 있는 옵션(applyToBaseline)이 추가되었습니다.

* **동작 변경**
  * 옵션이 true일 때 기준선의 목표 가중치가 입력값으로 유효하게 갱신·저장됩니다. 기준선이 없으면 기준선 갱신은 건너뛰며, 기준선에 없는 자산이 포함되면 오류로 처리됩니다.

* **테스트**
  * applyToBaseline이 true/false/null 및 기준선 부재/불일치 케이스에 대한 엔드투엔드 테스트가 추가·확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->