### PR TITLE
포트폴리오 list 에 draft 상태 삭제

### DIFF
--- a/src/main/java/com/porcana/domain/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/com/porcana/domain/portfolio/repository/PortfolioRepository.java
@@ -57,6 +57,11 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, UUID> {
     List<Portfolio> findByGuestSessionIdAndDeletedAtIsNullOrderByCreatedAtDesc(UUID guestSessionId);
 
     /**
+     * Find active and finished portfolios for a guest session (exclude DRAFT and deleted)
+     */
+    List<Portfolio> findByGuestSessionIdAndStatusNotAndDeletedAtIsNullOrderByCreatedAtDesc(UUID guestSessionId, PortfolioStatus status);
+
+    /**
      * Find portfolio by ID and guest session ID (ownership validation, excluding deleted)
      */
     Optional<Portfolio> findByIdAndGuestSessionIdAndDeletedAtIsNull(UUID id, UUID guestSessionId);

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -60,20 +60,21 @@ public class PortfolioService {
 
     /**
      * Get portfolios for user or guest session
+     * Excludes DRAFT status portfolios (Arena in progress)
      */
     public List<PortfolioListResponse> getPortfolios(UUID userId, UUID guestSessionId) {
         List<Portfolio> portfolios;
         UUID mainPortfolioId = null;
 
         if (userId != null) {
-            // Authenticated user
+            // Authenticated user - exclude DRAFT status
             User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                     .orElseThrow(() -> new IllegalArgumentException("User not found"));
-            portfolios = portfolioRepository.findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId);
+            portfolios = portfolioRepository.findByUserIdAndStatusNotAndDeletedAtIsNullOrderByCreatedAtDesc(userId, PortfolioStatus.DRAFT);
             mainPortfolioId = user.getMainPortfolioId();
         } else if (guestSessionId != null) {
-            // Guest session
-            portfolios = portfolioRepository.findByGuestSessionIdAndDeletedAtIsNullOrderByCreatedAtDesc(guestSessionId);
+            // Guest session - exclude DRAFT status
+            portfolios = portfolioRepository.findByGuestSessionIdAndStatusNotAndDeletedAtIsNullOrderByCreatedAtDesc(guestSessionId, PortfolioStatus.DRAFT);
         } else {
             throw new IllegalArgumentException("Either userId or guestSessionId must be provided");
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 포트폴리오 목록에서 진행 중인 드래프트 상태의 포트폴리오가 더 이상 표시되지 않습니다. 이제 완료되었거나 활성 상태의 포트폴리오만 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->