### PR TITLE
Feat: Google OAuth 다중 Client ID 지원 (iOS/Android/Web)

### DIFF
--- a/src/main/java/com/porcana/domain/auth/oauth/GoogleOAuth2Provider.java
+++ b/src/main/java/com/porcana/domain/auth/oauth/GoogleOAuth2Provider.java
@@ -17,6 +17,7 @@ import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
+import java.util.List;
 
 /**
  * Google OAuth2 Provider implementation
@@ -30,8 +31,8 @@ public class GoogleOAuth2Provider implements OAuth2Provider {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
 
-    @Value("${oauth.google.client-id:}")
-    private String clientId;
+    @Value("${oauth.google.client-ids:}")
+    private List<String> clientIds;
 
     private static final String JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
     private static final String GOOGLE_ISSUER = "https://accounts.google.com";
@@ -73,16 +74,21 @@ public class GoogleOAuth2Provider implements OAuth2Provider {
                 throw new IllegalArgumentException("Invalid issuer: " + issuer);
             }
 
-            // Step 4: Verify audience (client ID)
+            // Step 4: Verify audience (client ID) - allow multiple client IDs for iOS/Android/Web
             Object audClaim = claims.get("aud");
+            List<String> validClientIds = clientIds.stream()
+                    .filter(id -> id != null && !id.isBlank())
+                    .toList();
+
             boolean audienceValid = false;
-            if (audClaim instanceof String) {
-                audienceValid = clientId.equals(audClaim);
-            } else if (audClaim instanceof java.util.Collection) {
-                audienceValid = ((java.util.Collection<?>) audClaim).contains(clientId);
+            if (audClaim instanceof String aud) {
+                audienceValid = validClientIds.contains(aud);
+            } else if (audClaim instanceof java.util.Collection<?> audList) {
+                audienceValid = audList.stream()
+                        .anyMatch(aud -> validClientIds.contains(aud));
             }
             if (!audienceValid) {
-                log.warn("Audience mismatch - expected: {}, actual: {}", clientId, audClaim);
+                log.warn("Audience mismatch - expected one of: {}, actual: {}", validClientIds, audClaim);
                 throw new IllegalArgumentException("Invalid audience");
             }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,10 @@ jwt:
 
 oauth:
   google:
-    client-id: ${GOOGLE_CLIENT_ID:}
+    client-ids:
+      - ${GOOGLE_IOS_CLIENT_ID:}
+      - ${GOOGLE_ANDROID_CLIENT_ID:}
+      - ${GOOGLE_WEB_CLIENT_ID:}
   apple:
     client-id: ${APPLE_CLIENT_ID:}
     team-id: ${APPLE_TEAM_ID:}


### PR DESCRIPTION
iOS와 Android에서 각각 다른 Google Client ID를 사용하는 문제 해결
- 단일 client-id에서 client-ids 리스트로 변경
- 토큰 검증 시 여러 Client ID 중 하나와 매칭되면 통과
- 환경변수: GOOGLE_IOS_CLIENT_ID, GOOGLE_ANDROID_CLIENT_ID, GOOGLE_WEB_CLIENT_ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* Google OAuth2 인증이 여러 플랫폼을 위한 클라이언트 식별자를 지원합니다. iOS, Android, 웹 애플리케이션 각각에 대해 독립적인 클라이언트 ID를 설정할 수 있으며, 각 플랫폼의 로그인 토큰이 올바르게 검증됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->