### PR TITLE
Feat: 아레나 새로고침, 시드 미리보기 API 추가

### DIFF
--- a/src/main/java/com/porcana/domain/arena/ArenaController.java
+++ b/src/main/java/com/porcana/domain/arena/ArenaController.java
@@ -80,7 +80,7 @@ public class ArenaController {
 
     @Operation(
             summary = "현재 라운드 조회",
-            description = "현재 진행 중인 라운드의 선택지를 조회합니다. Round 0은 투자성향+섹터 동시 선택, Round 1-10은 자산 선택입니다. 비회원도 사용 가능합니다.",
+            description = "현재 진행 중인 라운드의 선택지를 조회합니다. Round 0은 투자성향+섹터 동시 선택, Round 1-10은 자산 선택입니다. refresh=true로 호출하면 Round 1-10의 선택지를 새로 생성합니다. 비회원도 사용 가능합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회 성공"),
                     @ApiResponse(responseCode = "400", description = "세션이 이미 완료됨", content = @Content),
@@ -90,12 +90,14 @@ public class ArenaController {
     @GetMapping("/sessions/{sessionId}/rounds/current")
     public ResponseEntity<RoundResponse> getCurrentRound(
             @Parameter(description = "세션 ID", required = true) @PathVariable UUID sessionId,
+            @Parameter(description = "true면 현재 라운드 선택지를 새로 생성 (Round 1-10만 가능)")
+            @RequestParam(defaultValue = "false") boolean refresh,
             HttpServletRequest request) {
 
         UUID userId = extractUserId();
         UUID guestSessionId = guestSessionExtractor.extractGuestSessionId(request);
 
-        RoundResponse response = arenaService.getCurrentRound(sessionId, userId, guestSessionId);
+        RoundResponse response = arenaService.getCurrentRound(sessionId, userId, guestSessionId, refresh);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/porcana/domain/arena/repository/ArenaRoundRepository.java
+++ b/src/main/java/com/porcana/domain/arena/repository/ArenaRoundRepository.java
@@ -35,4 +35,10 @@ public interface ArenaRoundRepository extends JpaRepository<ArenaRound, UUID> {
      * Returns the number of deleted rounds
      */
     int deleteBySessionId(UUID sessionId);
+
+    /**
+     * Delete a specific round by session ID and round number
+     * Used for refreshing current round options
+     */
+    void deleteBySessionIdAndRoundNumber(UUID sessionId, Integer roundNumber);
 }

--- a/src/main/java/com/porcana/domain/arena/service/ArenaService.java
+++ b/src/main/java/com/porcana/domain/arena/service/ArenaService.java
@@ -135,6 +135,14 @@ public class ArenaService {
      */
     @Transactional
     public RoundResponse getCurrentRound(UUID sessionId, UUID userId, UUID guestSessionId) {
+        return getCurrentRound(sessionId, userId, guestSessionId, false);
+    }
+
+    /**
+     * Get current round data with optional refresh (supports both user and guest)
+     */
+    @Transactional
+    public RoundResponse getCurrentRound(UUID sessionId, UUID userId, UUID guestSessionId, boolean refresh) {
         ArenaSession session = getSessionAndValidateOwnership(sessionId, userId, guestSessionId);
 
         if (session.getStatus() == SessionStatus.COMPLETED) {
@@ -143,12 +151,20 @@ public class ArenaService {
 
         int currentRound = session.getCurrentRound();
 
-        // Round 0: Pre Round (Risk Profile + Sector Selection)
+        // Round 0: Pre Round (Risk Profile + Sector Selection) - refresh not applicable
         if (currentRound == 0) {
+            if (refresh) {
+                throw new InvalidOperationException("Round 0에서는 새로고침을 사용할 수 없습니다");
+            }
             return buildPreRound(session);
         }
 
         // Rounds 1-10: Asset Selection
+        // If refresh requested, delete existing round to force new generation
+        if (refresh) {
+            roundRepository.deleteBySessionIdAndRoundNumber(session.getId(), currentRound);
+        }
+
         return buildAssetRound(session);
     }
 

--- a/src/main/java/com/porcana/domain/arena/service/AssetRecommendationService.java
+++ b/src/main/java/com/porcana/domain/arena/service/AssetRecommendationService.java
@@ -29,6 +29,7 @@ public class AssetRecommendationService {
 
     private final AssetRepository assetRepository;
     private final ArenaRoundRepository roundRepository;
+    private final Random random;
 
     // Bucket sizes
     private static final int PREFERRED_BUCKET_SIZE = 80;
@@ -117,9 +118,14 @@ public class AssetRecommendationService {
      * Generate random UUID for PK range sampling
      */
     private UUID generateRandomId() {
-        // Simple random UUID generation
-        // In production, could cache min/max and generate within range
-        return UUID.randomUUID();
+        // Generate UUID using injected Random for testability
+        byte[] randomBytes = new byte[16];
+        random.nextBytes(randomBytes);
+        randomBytes[6] &= 0x0f;  // clear version
+        randomBytes[6] |= 0x40;  // set to version 4
+        randomBytes[8] &= 0x3f;  // clear variant
+        randomBytes[8] |= 0x80;  // set to IETF variant
+        return UUID.nameUUIDFromBytes(randomBytes);
     }
 
     /**
@@ -351,7 +357,7 @@ public class AssetRecommendationService {
      */
     private Asset sampleByWeight(List<Asset> candidates, Map<UUID, Double> weights) {
         double total = weights.values().stream().mapToDouble(Double::doubleValue).sum();
-        double r = Math.random() * total;
+        double r = random.nextDouble() * total;
         double acc = 0;
 
         for (Asset asset : candidates) {

--- a/src/main/java/com/porcana/domain/arena/service/AssetRecommendationService.java
+++ b/src/main/java/com/porcana/domain/arena/service/AssetRecommendationService.java
@@ -125,7 +125,17 @@ public class AssetRecommendationService {
         randomBytes[6] |= 0x40;  // set to version 4
         randomBytes[8] &= 0x3f;  // clear variant
         randomBytes[8] |= 0x80;  // set to IETF variant
-        return UUID.nameUUIDFromBytes(randomBytes);
+
+        long msb = 0L;
+        long lsb = 0L;
+        for (int i = 0; i < 8; i++) {
+            msb = (msb << 8) | (randomBytes[i] & 0xffL);
+        }
+
+        for (int i = 8; i < 16; i++) {
+            lsb = (lsb << 8) | (randomBytes[i] & 0xffL);
+        }
+        return new UUID(msb, lsb);
     }
 
     /**

--- a/src/main/java/com/porcana/domain/portfolio/controller/HoldingBaselineController.java
+++ b/src/main/java/com/porcana/domain/portfolio/controller/HoldingBaselineController.java
@@ -27,11 +27,10 @@ public class HoldingBaselineController {
     @GetMapping("/seed/preview")
     public ResponseEntity<BaselineResponse> previewSeed(
             @PathVariable UUID portfolioId,
-            @RequestParam BigDecimal seedMoney,
-            @RequestParam(defaultValue = "KRW") String baseCurrency,
+            @Valid @RequestBody SetSeedRequest request,
             @CurrentUser UUID userId) {
 
-        BaselineResponse response = holdingBaselineService.previewSeed(portfolioId, userId, seedMoney, baseCurrency);
+        BaselineResponse response = holdingBaselineService.previewSeed(portfolioId, userId, request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/porcana/domain/portfolio/controller/HoldingBaselineController.java
+++ b/src/main/java/com/porcana/domain/portfolio/controller/HoldingBaselineController.java
@@ -23,6 +23,18 @@ public class HoldingBaselineController {
 
     private final HoldingBaselineService holdingBaselineService;
 
+    @Operation(summary = "시드 금액 미리보기", description = "시드 금액으로 각 종목별 매수 수량을 계산하여 미리 확인합니다. 저장되지 않습니다.")
+    @GetMapping("/seed/preview")
+    public ResponseEntity<BaselineResponse> previewSeed(
+            @PathVariable UUID portfolioId,
+            @RequestParam BigDecimal seedMoney,
+            @RequestParam(defaultValue = "KRW") String baseCurrency,
+            @CurrentUser UUID userId) {
+
+        BaselineResponse response = holdingBaselineService.previewSeed(portfolioId, userId, seedMoney, baseCurrency);
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "시드 금액 설정", description = "포트폴리오에 시드 금액을 설정하고 각 종목별 매수 수량을 계산합니다.")
     @PutMapping("/seed")
     public ResponseEntity<BaselineResponse> setSeed(

--- a/src/main/java/com/porcana/domain/portfolio/service/HoldingBaselineService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/HoldingBaselineService.java
@@ -16,6 +16,7 @@ import com.porcana.domain.portfolio.entity.PortfolioHoldingBaselineItem;
 import com.porcana.domain.portfolio.repository.PortfolioAssetRepository;
 import com.porcana.domain.portfolio.repository.PortfolioHoldingBaselineRepository;
 import com.porcana.domain.portfolio.repository.PortfolioRepository;
+import com.porcana.global.exception.InvalidOperationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +37,86 @@ public class HoldingBaselineService {
     private final AssetRepository assetRepository;
     private final AssetPriceRepository assetPriceRepository;
     private final ExchangeRateRepository exchangeRateRepository;
+
+    /**
+     * 시드 금액 미리보기 (저장하지 않음)
+     * 포트폴리오 비중과 현재가를 기반으로 각 종목별 수량 계산 결과만 반환
+     */
+    @Transactional(readOnly = true)
+    public BaselineResponse previewSeed(UUID portfolioId, UUID userId, BigDecimal seedMoney, String baseCurrency) {
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new IllegalArgumentException("포트폴리오를 찾을 수 없습니다: " + portfolioId));
+
+        validateOwnership(portfolio, userId);
+
+        List<PortfolioAsset> portfolioAssets = portfolioAssetRepository.findByPortfolioId(portfolioId);
+        if (portfolioAssets.isEmpty()) {
+            throw new IllegalStateException("포트폴리오에 자산이 없습니다.");
+        }
+
+        List<UUID> assetIds = portfolioAssets.stream()
+                .map(PortfolioAsset::getAssetId)
+                .toList();
+        Map<UUID, Asset> assetMap = assetRepository.findAllById(assetIds).stream()
+                .collect(Collectors.toMap(Asset::getId, a -> a));
+
+        BigDecimal usdKrw = getLatestExchangeRate();
+        PortfolioHoldingBaseline.Currency currency = parseCurrency(baseCurrency);
+        boolean isUsdBase = currency == PortfolioHoldingBaseline.Currency.USD;
+
+        Map<UUID, BigDecimal> latestPrices = getLatestPricesBatch(assetIds);
+
+        List<CalculatedItem> calculatedItems = new ArrayList<>();
+        BigDecimal totalInvested = BigDecimal.ZERO;
+
+        for (PortfolioAsset pa : portfolioAssets) {
+            Asset asset = assetMap.get(pa.getAssetId());
+            if (asset == null) continue;
+
+            BigDecimal currentPrice = latestPrices.get(asset.getId());
+            if (currentPrice == null || currentPrice.compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
+
+            BigDecimal priceInBaseCurrency;
+            if (isUsdBase) {
+                priceInBaseCurrency = asset.getMarket() == Asset.Market.KR
+                        ? currentPrice.divide(usdKrw, 4, RoundingMode.HALF_UP)
+                        : currentPrice;
+            } else {
+                priceInBaseCurrency = asset.getMarket() == Asset.Market.US
+                        ? currentPrice.multiply(usdKrw)
+                        : currentPrice;
+            }
+
+            BigDecimal targetAmount = seedMoney.multiply(pa.getWeightPct()).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+            int quantity = targetAmount.divide(priceInBaseCurrency, 0, RoundingMode.DOWN).intValue();
+            BigDecimal actualAmount = priceInBaseCurrency.multiply(BigDecimal.valueOf(quantity));
+            totalInvested = totalInvested.add(actualAmount);
+
+            calculatedItems.add(new CalculatedItem(
+                    asset,
+                    pa.getWeightPct(),
+                    BigDecimal.valueOf(quantity),
+                    currentPrice,
+                    priceInBaseCurrency
+            ));
+        }
+
+        BigDecimal cashAmount = seedMoney.subtract(totalInvested);
+
+        // Preview용 임시 Baseline 생성 (저장하지 않음)
+        PortfolioHoldingBaseline previewBaseline = PortfolioHoldingBaseline.create(
+                portfolioId,
+                userId,
+                PortfolioHoldingBaseline.SourceType.SEEDED,
+                currency,
+                cashAmount,
+                "미리보기"
+        );
+
+        return buildBaselineResponse(previewBaseline, calculatedItems, seedMoney);
+    }
 
     /**
      * 시드 금액으로 Baseline 설정
@@ -126,9 +207,10 @@ public class HoldingBaselineService {
         // 잔여 현금
         BigDecimal cashAmount = seedMoney.subtract(totalInvested);
 
-        // 기존 Baseline 삭제 후 새로 생성
-        baselineRepository.findByPortfolioId(portfolioId)
-                .ifPresent(baselineRepository::delete);
+        // 이미 Baseline이 존재하면 예외 발생
+        if (baselineRepository.existsByPortfolioId(portfolioId)) {
+            throw new InvalidOperationException("이미 시드 금액이 설정되어 있습니다. 기존 설정을 수정하려면 다른 API를 사용해주세요.");
+        }
 
         PortfolioHoldingBaseline baseline = PortfolioHoldingBaseline.create(
                 portfolioId,

--- a/src/main/java/com/porcana/domain/portfolio/service/HoldingBaselineService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/HoldingBaselineService.java
@@ -43,7 +43,7 @@ public class HoldingBaselineService {
      * 포트폴리오 비중과 현재가를 기반으로 각 종목별 수량 계산 결과만 반환
      */
     @Transactional(readOnly = true)
-    public BaselineResponse previewSeed(UUID portfolioId, UUID userId, BigDecimal seedMoney, String baseCurrency) {
+    public BaselineResponse previewSeed(UUID portfolioId, UUID userId, SetSeedRequest request) throws InvalidOperationException {
         Portfolio portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new IllegalArgumentException("포트폴리오를 찾을 수 없습니다: " + portfolioId));
 
@@ -61,7 +61,7 @@ public class HoldingBaselineService {
                 .collect(Collectors.toMap(Asset::getId, a -> a));
 
         BigDecimal usdKrw = getLatestExchangeRate();
-        PortfolioHoldingBaseline.Currency currency = parseCurrency(baseCurrency);
+        PortfolioHoldingBaseline.Currency currency = parseCurrency(request.baseCurrency());
         boolean isUsdBase = currency == PortfolioHoldingBaseline.Currency.USD;
 
         Map<UUID, BigDecimal> latestPrices = getLatestPricesBatch(assetIds);
@@ -71,11 +71,13 @@ public class HoldingBaselineService {
 
         for (PortfolioAsset pa : portfolioAssets) {
             Asset asset = assetMap.get(pa.getAssetId());
-            if (asset == null) continue;
+            if (asset == null) {
+                throw new IllegalStateException("포트폴리오 자산 정보를 찾을 수 없습니다: " + pa.getAssetId());
+            }
 
             BigDecimal currentPrice = latestPrices.get(asset.getId());
             if (currentPrice == null || currentPrice.compareTo(BigDecimal.ZERO) <= 0) {
-                continue;
+                throw new IllegalStateException("최신 가격 정보가 없습니다: " + asset.getSymbol());
             }
 
             BigDecimal priceInBaseCurrency;
@@ -89,7 +91,7 @@ public class HoldingBaselineService {
                         : currentPrice;
             }
 
-            BigDecimal targetAmount = seedMoney.multiply(pa.getWeightPct()).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+            BigDecimal targetAmount = request.seedMoney().multiply(pa.getWeightPct()).divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
             int quantity = targetAmount.divide(priceInBaseCurrency, 0, RoundingMode.DOWN).intValue();
             BigDecimal actualAmount = priceInBaseCurrency.multiply(BigDecimal.valueOf(quantity));
             totalInvested = totalInvested.add(actualAmount);
@@ -103,7 +105,7 @@ public class HoldingBaselineService {
             ));
         }
 
-        BigDecimal cashAmount = seedMoney.subtract(totalInvested);
+        BigDecimal cashAmount = request.seedMoney().subtract(totalInvested);
 
         // Preview용 임시 Baseline 생성 (저장하지 않음)
         PortfolioHoldingBaseline previewBaseline = PortfolioHoldingBaseline.create(
@@ -115,7 +117,7 @@ public class HoldingBaselineService {
                 "미리보기"
         );
 
-        return buildBaselineResponse(previewBaseline, calculatedItems, seedMoney);
+        return buildBaselineResponse(previewBaseline, calculatedItems, request.seedMoney());
     }
 
     /**
@@ -129,6 +131,11 @@ public class HoldingBaselineService {
 
         // 포트폴리오 소유자 확인
         validateOwnership(portfolio, userId);
+
+        // 이미 Baseline이 존재하면 예외 발생
+        if (baselineRepository.existsByPortfolioId(portfolioId)) {
+            throw new InvalidOperationException("이미 시드 금액이 설정되어 있습니다. 기존 설정을 수정하려면 다른 API를 사용해주세요.");
+        }
 
         // 포트폴리오 자산 조회
         List<PortfolioAsset> portfolioAssets = portfolioAssetRepository.findByPortfolioId(portfolioId);
@@ -206,11 +213,6 @@ public class HoldingBaselineService {
 
         // 잔여 현금
         BigDecimal cashAmount = seedMoney.subtract(totalInvested);
-
-        // 이미 Baseline이 존재하면 예외 발생
-        if (baselineRepository.existsByPortfolioId(portfolioId)) {
-            throw new InvalidOperationException("이미 시드 금액이 설정되어 있습니다. 기존 설정을 수정하려면 다른 API를 사용해주세요.");
-        }
 
         PortfolioHoldingBaseline baseline = PortfolioHoldingBaseline.create(
                 portfolioId,

--- a/src/main/java/com/porcana/global/config/AppConfig.java
+++ b/src/main/java/com/porcana/global/config/AppConfig.java
@@ -1,0 +1,19 @@
+package com.porcana.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Random;
+
+@Configuration
+public class AppConfig {
+
+    /**
+     * Random bean for services that need randomness
+     * Can be overridden in tests with fixed seed for deterministic results
+     */
+    @Bean
+    public Random random() {
+        return new Random();
+    }
+}

--- a/src/test/java/com/porcana/config/ArenaTestConfig.java
+++ b/src/test/java/com/porcana/config/ArenaTestConfig.java
@@ -1,0 +1,26 @@
+package com.porcana.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.util.Random;
+
+/**
+ * Arena 테스트용 Configuration
+ * 고정 seed Random을 주입하여 결정적인 테스트 결과 보장
+ */
+@TestConfiguration
+public class ArenaTestConfig {
+
+    /**
+     * 테스트용 고정 seed Random
+     * 서로 다른 seed를 사용하면 다른 결과가 나옴
+     */
+    @Bean
+    @Primary
+    public Random testRandom() {
+        // 고정 seed로 결정적인 결과 보장
+        return new Random(12345L);
+    }
+}

--- a/src/test/java/com/porcana/domain/arena/ArenaControllerTest.java
+++ b/src/test/java/com/porcana/domain/arena/ArenaControllerTest.java
@@ -346,6 +346,74 @@ class ArenaControllerTest extends BaseIntegrationTest {
     }
 
     @Test
+    @DisplayName("라운드 선택지 새로고침 성공 - Round 1-10")
+    void refreshCurrentRound_success() {
+        String sessionId = createSessionAndPickPreferences();
+
+        // 첫 번째 호출 - 기존 선택지 조회
+        List<String> originalAssetIds = given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .get("/arena/sessions/{sessionId}/rounds/current", sessionId)
+        .then()
+                .statusCode(200)
+                .body("roundType", equalTo("ASSET"))
+                .body("assets", hasSize(3))
+                .extract()
+                .path("assets.assetId");
+
+        // refresh=true로 호출 - 새로운 선택지 생성
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .get("/arena/sessions/{sessionId}/rounds/current?refresh=true", sessionId)
+        .then()
+                .log().all()
+                .statusCode(200)
+                .body("roundType", equalTo("ASSET"))
+                .body("assets", hasSize(3))
+                .body("round", equalTo(1));
+
+        // 세 번째 호출 (refresh=false) - 새로 생성된 선택지 유지 확인
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .get("/arena/sessions/{sessionId}/rounds/current", sessionId)
+        .then()
+                .statusCode(200)
+                .body("roundType", equalTo("ASSET"))
+                .body("assets", hasSize(3));
+    }
+
+    @Test
+    @DisplayName("라운드 선택지 새로고침 실패 - Round 0에서는 불가")
+    void refreshCurrentRound_fail_round0() {
+        // Create session (starts at Round 0)
+        CreateSessionRequest createRequest = new CreateSessionRequest(TEST_PORTFOLIO_ID);
+
+        String sessionId = given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer " + accessToken)
+                .body(createRequest)
+        .when()
+                .post("/arena/sessions")
+        .then()
+                .statusCode(200)
+                .extract()
+                .path("sessionId");
+
+        // Round 0에서 refresh=true 호출 시 에러
+        given()
+                .header("Authorization", "Bearer " + accessToken)
+        .when()
+                .get("/arena/sessions/{sessionId}/rounds/current?refresh=true", sessionId)
+        .then()
+                .log().all()
+                .statusCode(400)
+                .body("code", equalTo("INVALID_OPERATION"));
+    }
+
+    @Test
     @DisplayName("전체 아레나 플로우 테스트")
     void fullArenaFlow_success() {
         // 1. Create session

--- a/src/test/java/com/porcana/domain/arena/ArenaControllerTest.java
+++ b/src/test/java/com/porcana/domain/arena/ArenaControllerTest.java
@@ -1,6 +1,7 @@
 package com.porcana.domain.arena;
 
 import com.porcana.BaseIntegrationTest;
+import com.porcana.config.ArenaTestConfig;
 import com.porcana.domain.arena.dto.CreateSessionRequest;
 import com.porcana.domain.arena.dto.PickAssetRequest;
 import com.porcana.domain.arena.dto.PickPreferencesRequest;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.Arrays;
@@ -24,6 +26,7 @@ import java.util.UUID;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
+@Import(ArenaTestConfig.class)
 @Sql(scripts = "/sql/arena-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 class ArenaControllerTest extends BaseIntegrationTest {
 
@@ -363,7 +366,7 @@ class ArenaControllerTest extends BaseIntegrationTest {
                 .path("assets.assetId");
 
         // refresh=true로 호출 - 새로운 선택지 생성
-        given()
+        List<String> refreshedAssetIds = given()
                 .header("Authorization", "Bearer " + accessToken)
         .when()
                 .get("/arena/sessions/{sessionId}/rounds/current?refresh=true", sessionId)
@@ -372,7 +375,8 @@ class ArenaControllerTest extends BaseIntegrationTest {
                 .statusCode(200)
                 .body("roundType", equalTo("ASSET"))
                 .body("assets", hasSize(3))
-                .body("round", equalTo(1));
+                .body("assets.assetId", not(equalTo(originalAssetIds)))
+                .extract().path("assets.assetId");
 
         // 세 번째 호출 (refresh=false) - 새로 생성된 선택지 유지 확인
         given()
@@ -382,7 +386,8 @@ class ArenaControllerTest extends BaseIntegrationTest {
         .then()
                 .statusCode(200)
                 .body("roundType", equalTo("ASSET"))
-                .body("assets", hasSize(3));
+                .body("assets", hasSize(3))
+                .body("assets.assetId", containsInAnyOrder(refreshedAssetIds.toArray()));
     }
 
     @Test

--- a/src/test/resources/sql/arena-test-data.sql
+++ b/src/test/resources/sql/arena-test-data.sql
@@ -16,17 +16,32 @@ INSERT INTO portfolios (id, user_id, name, status, created_at, updated_at)
 VALUES ('22222222-2222-2222-2222-222222222222', '11111111-1111-1111-1111-111111111111', '테스트 포트폴리오', 'DRAFT', NOW(), NOW());
 
 -- 테스트용 Asset 데이터 생성 (다양한 섹터와 리스크 레벨)
+-- 새로고침 테스트를 위해 충분한 자산 풀 확보
 INSERT INTO assets (id, market, symbol, name, type, sector, current_risk_level, active, as_of, created_at, updated_at)
 VALUES
-    -- IT 섹터
+    -- IT 섹터 (10개)
     ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'US', 'AAPL', 'Apple Inc.', 'STOCK', 'INFORMATION_TECHNOLOGY', 3, true, CURRENT_DATE, NOW(), NOW()),
     ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab', 'US', 'MSFT', 'Microsoft Corp.', 'STOCK', 'INFORMATION_TECHNOLOGY', 2, true, CURRENT_DATE, NOW(), NOW()),
     ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaac', 'US', 'NVDA', 'NVIDIA Corp.', 'STOCK', 'INFORMATION_TECHNOLOGY', 4, true, CURRENT_DATE, NOW(), NOW()),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaad', 'US', 'AMD', 'AMD Inc.', 'STOCK', 'INFORMATION_TECHNOLOGY', 4, true, CURRENT_DATE, NOW(), NOW()),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaae', 'US', 'INTC', 'Intel Corp.', 'STOCK', 'INFORMATION_TECHNOLOGY', 3, true, CURRENT_DATE, NOW(), NOW()),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaf', 'US', 'CRM', 'Salesforce Inc.', 'STOCK', 'INFORMATION_TECHNOLOGY', 3, true, CURRENT_DATE, NOW(), NOW()),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa10', 'US', 'ORCL', 'Oracle Corp.', 'STOCK', 'INFORMATION_TECHNOLOGY', 2, true, CURRENT_DATE, NOW(), NOW()),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa11', 'US', 'CSCO', 'Cisco Systems', 'STOCK', 'INFORMATION_TECHNOLOGY', 2, true, CURRENT_DATE, NOW(), NOW()),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa12', 'US', 'ADBE', 'Adobe Inc.', 'STOCK', 'INFORMATION_TECHNOLOGY', 3, true, CURRENT_DATE, NOW(), NOW()),
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa13', 'US', 'IBM', 'IBM Corp.', 'STOCK', 'INFORMATION_TECHNOLOGY', 2, true, CURRENT_DATE, NOW(), NOW()),
 
-    -- Healthcare 섹터
+    -- Healthcare 섹터 (10개)
     ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'US', 'JNJ', 'Johnson & Johnson', 'STOCK', 'HEALTH_CARE', 2, true, CURRENT_DATE, NOW(), NOW()),
     ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbc', 'US', 'PFE', 'Pfizer Inc.', 'STOCK', 'HEALTH_CARE', 3, true, CURRENT_DATE, NOW(), NOW()),
     ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbd', 'US', 'UNH', 'UnitedHealth Group', 'STOCK', 'HEALTH_CARE', 2, true, CURRENT_DATE, NOW(), NOW()),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbe', 'US', 'ABBV', 'AbbVie Inc.', 'STOCK', 'HEALTH_CARE', 3, true, CURRENT_DATE, NOW(), NOW()),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbcf', 'US', 'MRK', 'Merck & Co.', 'STOCK', 'HEALTH_CARE', 2, true, CURRENT_DATE, NOW(), NOW()),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbb100', 'US', 'LLY', 'Eli Lilly', 'STOCK', 'HEALTH_CARE', 3, true, CURRENT_DATE, NOW(), NOW()),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbb101', 'US', 'TMO', 'Thermo Fisher', 'STOCK', 'HEALTH_CARE', 2, true, CURRENT_DATE, NOW(), NOW()),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbb102', 'US', 'DHR', 'Danaher Corp.', 'STOCK', 'HEALTH_CARE', 2, true, CURRENT_DATE, NOW(), NOW()),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbb103', 'US', 'BMY', 'Bristol-Myers', 'STOCK', 'HEALTH_CARE', 3, true, CURRENT_DATE, NOW(), NOW()),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbb104', 'US', 'AMGN', 'Amgen Inc.', 'STOCK', 'HEALTH_CARE', 2, true, CURRENT_DATE, NOW(), NOW()),
 
     -- Financials 섹터
     ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'US', 'JPM', 'JPMorgan Chase', 'STOCK', 'FINANCIALS', 3, true, CURRENT_DATE, NOW(), NOW()),


### PR DESCRIPTION
## Summary
- 아레나 라운드 선택지 새로고침 기능 추가 (`GET /rounds/current?refresh=true`)
- 시드 금액 미리보기 API 추가 (`GET /portfolios/{id}/seed/preview`)
- 시드 중복 설정 시 예외 처리 (`InvalidOperationException`)
- 성능 개선: `existsByPortfolioId()` 사용으로 불필요한 SELECT * 쿼리 제거

## Changes
| 파일 | 변경 내용 |
|------|----------|
| ArenaController.java | refresh 파라미터 추가 |
| ArenaRoundRepository.java | deleteBySessionIdAndRoundNumber 메서드 추가 |
| ArenaService.java | refresh 로직 구현 |
| HoldingBaselineController.java | previewSeed 엔드포인트 추가 |
| HoldingBaselineService.java | previewSeed 메서드 추가, 중복 설정 예외처리 |

## Test plan
- [ ] `GET /api/v1/arena/sessions/{id}/rounds/current` 호출 확인
- [ ] `GET /api/v1/arena/sessions/{id}/rounds/current?refresh=true` 호출 시 새 선택지 반환 확인
- [ ] Round 0에서 refresh=true 시 에러 반환 확인
- [ ] `GET /api/v1/portfolios/{id}/seed/preview?seedMoney=1000000&baseCurrency=KRW` 호출 확인
- [ ] 이미 시드 설정된 포트폴리오에 `PUT /seed` 호출 시 에러 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 경기장 현재 라운드에서 선택 옵션을 새로 생성하는 refresh 파라미터 추가
  * 포트폴리오 기초선 저장 전 결과를 확인하는 미리보기(preview) 엔드포인트 추가

* **개선 사항**
  * 기초선 저장 시 기존 기초선이 덮어써지지 않도록 검증 강화
  * 테스트 안정성을 위한 랜덤 시드 주입 지원

* **버그 수정**
  * 라운드 0에서 refresh 요청 시 올바른 오류(Invalid Operation) 반환

* **테스트**
  * 새로고침 동작 및 예외 검증 통합 테스트 추가, 테스트 데이터 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->