### PR TITLE
Fix: rebuild portfolio returns after rebalancing

### DIFF
--- a/src/main/java/com/porcana/batch/runner/PortfolioReturnRebuildRunner.java
+++ b/src/main/java/com/porcana/batch/runner/PortfolioReturnRebuildRunner.java
@@ -12,18 +12,19 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
 @Component
 @ConditionalOnProperty(
-        prefix = "batch.runner.portfolio-performance-backfill",
+        prefix = "batch.runner.portfolio-return-rebuild",
         name = "enabled",
         havingValue = "true",
         matchIfMissing = false
 )
 @RequiredArgsConstructor
-public class PortfolioPerformanceBackfillRunner implements ApplicationRunner {
+public class PortfolioReturnRebuildRunner implements ApplicationRunner {
 
     private final PortfolioRepository portfolioRepository;
     private final PortfolioPerformanceBackfillService portfolioPerformanceBackfillService;
@@ -31,39 +32,40 @@ public class PortfolioPerformanceBackfillRunner implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) {
         log.info("========================================");
-        log.info("Starting Portfolio Performance Backfill");
+        log.info("Starting Portfolio Return Rebuild Runner");
         log.info("========================================");
 
         LocalDate yesterday = LocalDate.now().minusDays(1);
-        List<Portfolio> portfolios = portfolioRepository.findByStatusAndDeletedAtIsNull(PortfolioStatus.ACTIVE);
-        log.info("Found {} active portfolios to backfill", portfolios.size());
+        List<Portfolio> portfolios = new ArrayList<>();
+        portfolios.addAll(portfolioRepository.findByStatusAndDeletedAtIsNull(PortfolioStatus.ACTIVE));
+        portfolios.addAll(portfolioRepository.findByStatusAndDeletedAtIsNull(PortfolioStatus.FINISHED));
+
+        log.info("Found {} portfolios to rebuild", portfolios.size());
 
         int successPortfolios = 0;
         int failedPortfolios = 0;
         int totalDaysInserted = 0;
-        int totalDaysSkipped = 0;
 
         for (int i = 0; i < portfolios.size(); i++) {
             Portfolio portfolio = portfolios.get(i);
-            log.info("[{}/{}] Processing portfolio {} (started: {})",
-                    i + 1, portfolios.size(), portfolio.getId(), portfolio.getStartedAt());
+            log.info("[{}/{}] Rebuilding portfolio {} (status: {}, started: {})",
+                    i + 1, portfolios.size(), portfolio.getId(), portfolio.getStatus(), portfolio.getStartedAt());
 
             try {
-                int[] result = portfolioPerformanceBackfillService.backfillPortfolio(portfolio, yesterday);
+                int[] result = portfolioPerformanceBackfillService.rebuildPortfolio(portfolio, yesterday);
                 totalDaysInserted += result[0];
-                totalDaysSkipped += result[1];
                 successPortfolios++;
-                log.info("  Completed: {} days inserted, {} days skipped", result[0], result[1]);
+                log.info("  Rebuilt: {} days inserted after purge", result[0]);
             } catch (Exception e) {
-                log.error("  Failed to backfill portfolio {}: {}", portfolio.getId(), e.getMessage(), e);
                 failedPortfolios++;
+                log.error("  Failed to rebuild portfolio {}: {}", portfolio.getId(), e.getMessage(), e);
             }
         }
 
         log.info("========================================");
-        log.info("Portfolio Performance Backfill completed");
+        log.info("Portfolio Return Rebuild completed");
         log.info("Portfolios: {} success, {} failed", successPortfolios, failedPortfolios);
-        log.info("Days: {} inserted, {} skipped", totalDaysInserted, totalDaysSkipped);
+        log.info("Days rebuilt: {}", totalDaysInserted);
         log.info("========================================");
     }
 }

--- a/src/main/java/com/porcana/batch/service/PortfolioPerformanceBackfillService.java
+++ b/src/main/java/com/porcana/batch/service/PortfolioPerformanceBackfillService.java
@@ -1,0 +1,351 @@
+package com.porcana.batch.service;
+
+import com.porcana.domain.asset.AssetPriceRepository;
+import com.porcana.domain.asset.AssetRepository;
+import com.porcana.domain.asset.entity.Asset;
+import com.porcana.domain.asset.entity.AssetPrice;
+import com.porcana.domain.exchangerate.ExchangeRateRepository;
+import com.porcana.domain.exchangerate.entity.CurrencyCode;
+import com.porcana.domain.exchangerate.entity.ExchangeRate;
+import com.porcana.domain.portfolio.entity.Portfolio;
+import com.porcana.domain.portfolio.entity.PortfolioDailyReturn;
+import com.porcana.domain.portfolio.entity.PortfolioSnapshot;
+import com.porcana.domain.portfolio.entity.PortfolioSnapshotAsset;
+import com.porcana.domain.portfolio.entity.SnapshotAssetDailyReturn;
+import com.porcana.domain.portfolio.repository.PortfolioDailyReturnRepository;
+import com.porcana.domain.portfolio.repository.PortfolioSnapshotAssetRepository;
+import com.porcana.domain.portfolio.repository.PortfolioSnapshotRepository;
+import com.porcana.domain.portfolio.repository.SnapshotAssetDailyReturnRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PortfolioPerformanceBackfillService {
+
+    private static final BigDecimal INITIAL_INVESTMENT_KRW = new BigDecimal("10000000.00");
+
+    private final PortfolioSnapshotRepository snapshotRepository;
+    private final PortfolioSnapshotAssetRepository snapshotAssetRepository;
+    private final AssetRepository assetRepository;
+    private final AssetPriceRepository assetPriceRepository;
+    private final ExchangeRateRepository exchangeRateRepository;
+    private final PortfolioDailyReturnRepository dailyReturnRepository;
+    private final SnapshotAssetDailyReturnRepository assetDailyReturnRepository;
+
+    @Transactional
+    public int[] backfillPortfolio(Portfolio portfolio, LocalDate endDate) {
+        int inserted = 0;
+        int skipped = 0;
+
+        LocalDate startDate = portfolio.getStartedAt();
+        if (startDate == null) {
+            log.warn("Portfolio {} has no startedAt date", portfolio.getId());
+            return new int[]{0, 0};
+        }
+
+        Map<UUID, Map<UUID, BigDecimal>> startPriceCache = new HashMap<>();
+
+        LocalDate currentDate = startDate;
+        while (!currentDate.isAfter(endDate)) {
+            if (dailyReturnRepository.existsByPortfolioIdAndReturnDate(portfolio.getId(), currentDate)) {
+                skipped++;
+                currentDate = currentDate.plusDays(1);
+                continue;
+            }
+
+            boolean success = calculateAndSavePerformance(portfolio, currentDate, startPriceCache);
+            if (success) {
+                inserted++;
+            }
+
+            currentDate = currentDate.plusDays(1);
+        }
+
+        return new int[]{inserted, skipped};
+    }
+
+    @Transactional
+    public int[] rebuildPortfolio(Portfolio portfolio, LocalDate endDate) {
+        int deletedAssetReturns = assetDailyReturnRepository.deleteByPortfolioId(portfolio.getId());
+        int deletedPortfolioReturns = dailyReturnRepository.deleteByPortfolioId(portfolio.getId());
+        assetDailyReturnRepository.flush();
+        dailyReturnRepository.flush();
+
+        log.info("Deleted {} asset returns and {} portfolio returns for portfolio {}",
+                deletedAssetReturns, deletedPortfolioReturns, portfolio.getId());
+
+        return backfillPortfolio(portfolio, endDate);
+    }
+
+    private boolean calculateAndSavePerformance(Portfolio portfolio, LocalDate targetDate,
+                                                Map<UUID, Map<UUID, BigDecimal>> startPriceCache) {
+        Optional<PortfolioSnapshot> snapshotOpt = snapshotRepository
+                .findFirstByPortfolioIdAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
+                        portfolio.getId(), targetDate);
+
+        if (snapshotOpt.isEmpty()) {
+            log.debug("No snapshot found for portfolio {} on or before {}", portfolio.getId(), targetDate);
+            return false;
+        }
+
+        PortfolioSnapshot snapshot = snapshotOpt.get();
+        LocalDate snapshotDate = snapshot.getEffectiveDate();
+
+        List<PortfolioSnapshotAsset> snapshotAssets = snapshotAssetRepository.findBySnapshotId(snapshot.getId());
+        if (snapshotAssets.isEmpty()) {
+            log.debug("Snapshot {} has no assets", snapshot.getId());
+            return false;
+        }
+
+        List<UUID> assetIds = snapshotAssets.stream()
+                .map(PortfolioSnapshotAsset::getAssetId)
+                .toList();
+        Map<UUID, Asset> assetMap = assetRepository.findAllById(assetIds).stream()
+                .collect(Collectors.toMap(Asset::getId, asset -> asset));
+
+        if (assetMap.size() != assetIds.size()) {
+            log.debug("Some assets not found for portfolio {}", portfolio.getId());
+            return false;
+        }
+
+        Map<UUID, BigDecimal> startPrices = startPriceCache.computeIfAbsent(snapshot.getId(), sid -> {
+            LocalDate startLookback = snapshotDate.minusDays(7);
+            Map<UUID, List<AssetPrice>> startPricesByAsset = loadPricesForAssets(assetIds, startLookback, snapshotDate);
+            Map<UUID, BigDecimal> result = new HashMap<>();
+            for (UUID assetId : assetIds) {
+                List<AssetPrice> prices = startPricesByAsset.getOrDefault(assetId, Collections.emptyList());
+                findClosestPriceFromList(prices, snapshotDate)
+                        .ifPresent(assetPrice -> result.put(assetId, assetPrice.getPrice()));
+            }
+            return result;
+        });
+
+        LocalDate targetLookback = targetDate.minusDays(7);
+        Map<UUID, List<AssetPrice>> targetPricesByAsset = loadPricesForAssets(assetIds, targetLookback, targetDate);
+
+        List<AssetCalculation> calculations = new ArrayList<>();
+        BigDecimal totalCurrentValueKrw = BigDecimal.ZERO;
+
+        for (PortfolioSnapshotAsset snapshotAsset : snapshotAssets) {
+            Asset asset = assetMap.get(snapshotAsset.getAssetId());
+
+            BigDecimal startPrice = startPrices.get(asset.getId());
+            if (startPrice == null) {
+                log.debug("No start price for asset {} on {}", asset.getSymbol(), snapshotDate);
+                return false;
+            }
+
+            List<AssetPrice> targetPrices = targetPricesByAsset.getOrDefault(asset.getId(), Collections.emptyList());
+            Optional<AssetPrice> targetPriceOpt = findClosestPriceFromList(targetPrices, targetDate);
+            if (targetPriceOpt.isEmpty()) {
+                log.debug("No target price for asset {} on {}", asset.getSymbol(), targetDate);
+                return false;
+            }
+            BigDecimal targetPrice = targetPriceOpt.get().getPrice();
+
+            Optional<AssetReturnResult> resultOpt = calculateAssetReturnFromPrices(asset, startPrice, targetPrice, snapshotDate, targetDate);
+            if (resultOpt.isEmpty()) {
+                log.debug("Failed to calculate return for asset {} on {}", asset.getSymbol(), targetDate);
+                return false;
+            }
+
+            AssetReturnResult result = resultOpt.get();
+            BigDecimal initialWeight = snapshotAsset.getWeight();
+
+            BigDecimal initialValueKrw = INITIAL_INVESTMENT_KRW
+                    .multiply(initialWeight)
+                    .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+
+            BigDecimal returnMultiplier = BigDecimal.ONE.add(
+                    result.assetReturnTotal().divide(BigDecimal.valueOf(100), 8, RoundingMode.HALF_UP)
+            );
+            BigDecimal currentValueKrw = initialValueKrw.multiply(returnMultiplier)
+                    .setScale(2, RoundingMode.HALF_UP);
+
+            totalCurrentValueKrw = totalCurrentValueKrw.add(currentValueKrw);
+            calculations.add(new AssetCalculation(asset, snapshotAsset, result, initialWeight, currentValueKrw));
+        }
+
+        List<SnapshotAssetDailyReturn> assetReturns = new ArrayList<>();
+        BigDecimal totalReturnLocal = BigDecimal.ZERO;
+        BigDecimal totalReturnFx = BigDecimal.ZERO;
+
+        for (AssetCalculation calc : calculations) {
+            BigDecimal currentWeight = calc.initialWeight();
+            if (totalCurrentValueKrw.compareTo(BigDecimal.ZERO) > 0) {
+                currentWeight = calc.currentValueKrw()
+                        .divide(totalCurrentValueKrw, 6, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100));
+            }
+
+            BigDecimal contributionTotal = calc.result().assetReturnTotal()
+                    .multiply(calc.initialWeight())
+                    .divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP);
+
+            SnapshotAssetDailyReturn assetReturn = SnapshotAssetDailyReturn.from(
+                    portfolio.getId(),
+                    snapshot.getId(),
+                    calc.asset().getId(),
+                    targetDate,
+                    currentWeight,
+                    calc.result().assetReturnLocal(),
+                    calc.result().assetReturnTotal(),
+                    calc.result().fxReturn(),
+                    contributionTotal,
+                    calc.currentValueKrw()
+            );
+            assetReturns.add(assetReturn);
+
+            BigDecimal weightedReturnLocal = calc.result().assetReturnLocal()
+                    .multiply(calc.initialWeight())
+                    .divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP);
+
+            BigDecimal weightedReturnFx = calc.result().fxReturn()
+                    .multiply(calc.initialWeight())
+                    .divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP);
+
+            totalReturnLocal = totalReturnLocal.add(weightedReturnLocal);
+            totalReturnFx = totalReturnFx.add(weightedReturnFx);
+        }
+
+        BigDecimal totalReturn = totalReturnLocal.add(totalReturnFx);
+
+        PortfolioDailyReturn dailyReturn = PortfolioDailyReturn.from(
+                portfolio.getId(),
+                snapshot.getId(),
+                targetDate,
+                totalReturn,
+                totalReturnLocal,
+                totalReturnFx,
+                totalCurrentValueKrw
+        );
+
+        dailyReturnRepository.save(dailyReturn);
+        assetDailyReturnRepository.saveAll(assetReturns);
+
+        return true;
+    }
+
+    private Map<UUID, List<AssetPrice>> loadPricesForAssets(List<UUID> assetIds, LocalDate startDate, LocalDate endDate) {
+        if (assetIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<AssetPrice> allPrices = assetPriceRepository.findPricesByAssetIdsAndDateRange(assetIds, startDate, endDate);
+        return allPrices.stream()
+                .collect(Collectors.groupingBy(assetPrice -> assetPrice.getAsset().getId()));
+    }
+
+    private Optional<AssetReturnResult> calculateAssetReturnFromPrices(Asset asset, BigDecimal startPrice,
+                                                                       BigDecimal targetPrice, LocalDate startDate,
+                                                                       LocalDate targetDate) {
+        if (startPrice.compareTo(BigDecimal.ZERO) <= 0 || targetPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            log.warn("Invalid price for asset {} (start={}, target={})",
+                    asset.getSymbol(), startPrice, targetPrice);
+            return Optional.empty();
+        }
+
+        BigDecimal assetReturnLocal = targetPrice.subtract(startPrice)
+                .divide(startPrice, 6, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100));
+
+        BigDecimal fxReturn = BigDecimal.ZERO;
+        if (asset.getMarket() == Asset.Market.US) {
+            Optional<BigDecimal> fxReturnOpt = calculateFxReturn(startDate, targetDate);
+            if (fxReturnOpt.isEmpty()) {
+                return Optional.empty();
+            }
+            fxReturn = fxReturnOpt.get();
+        }
+
+        BigDecimal assetReturnTotal = assetReturnLocal.add(fxReturn);
+        return Optional.of(new AssetReturnResult(assetReturnLocal, fxReturn, assetReturnTotal));
+    }
+
+    private Optional<BigDecimal> calculateFxReturn(LocalDate startDate, LocalDate targetDate) {
+        Optional<ExchangeRate> startRateOpt = findClosestExchangeRate(CurrencyCode.USD, startDate);
+        if (startRateOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<ExchangeRate> targetRateOpt = findClosestExchangeRate(CurrencyCode.USD, targetDate);
+        if (targetRateOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        BigDecimal startRate = startRateOpt.get().getBaseRate();
+        BigDecimal targetRate = targetRateOpt.get().getBaseRate();
+
+        BigDecimal fxReturn = targetRate.subtract(startRate)
+                .divide(startRate, 6, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100));
+
+        return Optional.of(fxReturn);
+    }
+
+    private Optional<AssetPrice> findClosestPriceFromList(List<AssetPrice> prices, LocalDate date) {
+        if (prices.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<AssetPrice> exactMatch = prices.stream()
+                .filter(price -> price.getPriceDate().equals(date))
+                .findFirst();
+        if (exactMatch.isPresent()) {
+            return exactMatch;
+        }
+
+        LocalDate lookbackStart = date.minusDays(7);
+        return prices.stream()
+                .filter(price -> !price.getPriceDate().isAfter(date) && !price.getPriceDate().isBefore(lookbackStart))
+                .max(Comparator.comparing(AssetPrice::getPriceDate));
+    }
+
+    private Optional<ExchangeRate> findClosestExchangeRate(CurrencyCode currencyCode, LocalDate date) {
+        Optional<ExchangeRate> exactRate = exchangeRateRepository.findByCurrencyCodeAndExchangeDate(currencyCode, date);
+        if (exactRate.isPresent()) {
+            return exactRate;
+        }
+
+        LocalDate lookbackStart = date.minusDays(7);
+        List<ExchangeRate> rates = exchangeRateRepository.findByCurrencyCodeAndExchangeDateBetweenOrderByExchangeDateDesc(
+                currencyCode, lookbackStart, date);
+
+        if (rates.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(rates.get(0));
+    }
+
+    private record AssetReturnResult(
+            BigDecimal assetReturnLocal,
+            BigDecimal fxReturn,
+            BigDecimal assetReturnTotal
+    ) {}
+
+    private record AssetCalculation(
+            Asset asset,
+            PortfolioSnapshotAsset snapshotAsset,
+            AssetReturnResult result,
+            BigDecimal initialWeight,
+            BigDecimal currentValueKrw
+    ) {}
+}

--- a/src/main/java/com/porcana/domain/home/service/HomeService.java
+++ b/src/main/java/com/porcana/domain/home/service/HomeService.java
@@ -114,14 +114,11 @@ public class HomeService {
                     .build());
         }
 
-        // returnTotal is cumulative return (%) from snapshot start date, not daily return
-        for (PortfolioDailyReturn dailyReturn : returns) {
-            double returnTotalPct = dailyReturn.getReturnTotal().doubleValue();
-            double value = 100.0 + returnTotalPct;
-
+        for (PortfolioReturnCalculator.PortfolioValuePoint point :
+                portfolioReturnCalculator.calculatePortfolioValueSeries(returns, 100.0)) {
             chartPoints.add(HomeResponse.ChartPoint.builder()
-                    .date(dailyReturn.getReturnDate())
-                    .value(value)
+                    .date(point.date())
+                    .value(point.value())
                     .build());
         }
 

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioReturnCalculator.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioReturnCalculator.java
@@ -7,6 +7,7 @@ import com.porcana.domain.portfolio.repository.SnapshotAssetDailyReturnRepositor
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -15,10 +16,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-/**
- * 포트폴리오 및 자산별 수익률 계산을 담당하는 컴포넌트
- * HomeService와 PortfolioService에서 공통으로 사용
- */
 @Component
 @RequiredArgsConstructor
 public class PortfolioReturnCalculator {
@@ -27,11 +24,8 @@ public class PortfolioReturnCalculator {
     private final SnapshotAssetDailyReturnRepository snapshotAssetDailyReturnRepository;
 
     /**
-     * 포트폴리오 전체 누적 수익률 계산
-     * 각 스냅샷 기간의 마지막 수익률만 사용하여 복리 계산
-     *
-     * @param portfolioId 포트폴리오 ID
-     * @return 누적 수익률 (%)
+     * Calculate compounded portfolio return across snapshots.
+     * Each snapshot stores returns relative to its own effective date.
      */
     public Double calculateTotalReturn(UUID portfolioId) {
         List<PortfolioDailyReturn> returns = portfolioDailyReturnRepository
@@ -41,21 +35,18 @@ public class PortfolioReturnCalculator {
             return 0.0;
         }
 
-        // 스냅샷별로 그룹핑하여 각 스냅샷의 마지막 날짜 수익률만 추출
         Map<UUID, Optional<PortfolioDailyReturn>> lastBySnapshot = returns.stream()
                 .collect(Collectors.groupingBy(
                         PortfolioDailyReturn::getSnapshotId,
                         Collectors.maxBy(Comparator.comparing(PortfolioDailyReturn::getReturnDate))
                 ));
 
-        // 스냅샷 기간별 수익률을 날짜순으로 정렬
         List<PortfolioDailyReturn> periodReturns = lastBySnapshot.values().stream()
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .sorted(Comparator.comparing(PortfolioDailyReturn::getReturnDate))
-                .collect(Collectors.toList());
+                .toList();
 
-        // 스냅샷 기간별 수익률만 복리 계산: (1 + r1) * (1 + r2) * ... - 1
         double cumulativeReturn = 1.0;
         for (PortfolioDailyReturn periodReturn : periodReturns) {
             double periodReturnValue = periodReturn.getReturnTotal().doubleValue() / 100.0;
@@ -66,62 +57,66 @@ public class PortfolioReturnCalculator {
     }
 
     /**
-     * 자산별 누적 수익률 계산
-     * 각 스냅샷 기간의 마지막 수익률만 사용하여 복리 계산
-     *
-     * @param portfolioId 포트폴리오 ID
-     * @param assetIds    자산 ID 목록
-     * @return 자산 ID -> 누적 수익률(%) 맵
+     * Build a continuous chart series from snapshot-based cumulative returns.
+     * Snapshot changes should not reset the portfolio chart.
+     */
+    public List<PortfolioValuePoint> calculatePortfolioValueSeries(List<PortfolioDailyReturn> returns, double baseValue) {
+        if (returns.isEmpty()) {
+            return List.of();
+        }
+
+        List<PortfolioDailyReturn> sortedReturns = returns.stream()
+                .sorted(Comparator.comparing(PortfolioDailyReturn::getReturnDate))
+                .toList();
+
+        double carriedMultiplier = 1.0;
+        UUID currentSnapshotId = null;
+        double lastSnapshotMultiplier = 1.0;
+
+        java.util.ArrayList<PortfolioValuePoint> points = new java.util.ArrayList<>(sortedReturns.size());
+        for (PortfolioDailyReturn dailyReturn : sortedReturns) {
+            if (currentSnapshotId != null && !currentSnapshotId.equals(dailyReturn.getSnapshotId())) {
+                carriedMultiplier *= lastSnapshotMultiplier;
+            }
+
+            currentSnapshotId = dailyReturn.getSnapshotId();
+            lastSnapshotMultiplier = 1.0 + dailyReturn.getReturnTotal().doubleValue() / 100.0;
+
+            points.add(new PortfolioValuePoint(
+                    dailyReturn.getReturnDate(),
+                    baseValue * carriedMultiplier * lastSnapshotMultiplier
+            ));
+        }
+
+        return points;
+    }
+
+    /**
+     * Current asset return should reflect the latest snapshot only.
+     * After rebalancing, per-asset return resets to the new snapshot baseline.
      */
     public Map<UUID, Double> calculateAssetReturns(UUID portfolioId, Set<UUID> assetIds) {
-        // 해당 포트폴리오의 모든 자산별 일일 수익률 조회
         List<SnapshotAssetDailyReturn> assetReturns = snapshotAssetDailyReturnRepository
                 .findByPortfolioIdOrderByReturnDateAsc(portfolioId);
 
         if (assetReturns.isEmpty()) {
-            // 데이터가 없으면 모두 0.0으로 반환
             return assetIds.stream()
                     .collect(Collectors.toMap(assetId -> assetId, assetId -> 0.0));
         }
 
-        // 자산별로 그룹핑
         Map<UUID, List<SnapshotAssetDailyReturn>> assetReturnsByAsset = assetReturns.stream()
-                .filter(ar -> assetIds.contains(ar.getAssetId()))
+                .filter(assetReturn -> assetIds.contains(assetReturn.getAssetId()))
                 .collect(Collectors.groupingBy(SnapshotAssetDailyReturn::getAssetId));
 
-        // 각 자산별로 누적 수익률 계산
         return assetIds.stream()
                 .collect(Collectors.toMap(
                         assetId -> assetId,
-                        assetId -> {
-                            List<SnapshotAssetDailyReturn> dailyReturns = assetReturnsByAsset.get(assetId);
-                            if (dailyReturns == null || dailyReturns.isEmpty()) {
-                                return 0.0;
-                            }
-
-                            // 스냅샷별로 그룹핑하여 각 스냅샷의 마지막 날짜 수익률만 추출
-                            Map<UUID, Optional<SnapshotAssetDailyReturn>> lastBySnapshot = dailyReturns.stream()
-                                    .collect(Collectors.groupingBy(
-                                            SnapshotAssetDailyReturn::getSnapshotId,
-                                            Collectors.maxBy(Comparator.comparing(SnapshotAssetDailyReturn::getReturnDate))
-                                    ));
-
-                            // 스냅샷 기간별 수익률을 날짜순으로 정렬
-                            List<SnapshotAssetDailyReturn> periodReturns = lastBySnapshot.values().stream()
-                                    .filter(Optional::isPresent)
-                                    .map(Optional::get)
-                                    .sorted(Comparator.comparing(SnapshotAssetDailyReturn::getReturnDate))
-                                    .collect(Collectors.toList());
-
-                            // 스냅샷 기간별 수익률만 복리 계산: (1 + r1) * (1 + r2) * ... - 1
-                            double cumulativeReturn = 1.0;
-                            for (SnapshotAssetDailyReturn periodReturn : periodReturns) {
-                                double periodReturnValue = periodReturn.getAssetReturnTotal().doubleValue() / 100.0;
-                                cumulativeReturn *= (1.0 + periodReturnValue);
-                            }
-
-                            return (cumulativeReturn - 1.0) * 100.0;
-                        }
+                        assetId -> assetReturnsByAsset.getOrDefault(assetId, List.of()).stream()
+                                .max(Comparator.comparing(SnapshotAssetDailyReturn::getReturnDate))
+                                .map(snapshotAssetDailyReturn -> snapshotAssetDailyReturn.getAssetReturnTotal().doubleValue())
+                                .orElse(0.0)
                 ));
     }
+
+    public record PortfolioValuePoint(LocalDate date, double value) {}
 }

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -303,21 +303,15 @@ public class PortfolioService {
                 .value(100.0)
                 .build());
 
-        // Add performance points
-        // returnTotal is cumulative return (%) from snapshot start date, not daily return
-        for (PortfolioDailyReturn dailyReturn : returns) {
-            if (dailyReturn.getReturnDate().isBefore(initialDate) ||
-                dailyReturn.getReturnDate().isEqual(initialDate)) {
+        for (PortfolioReturnCalculator.PortfolioValuePoint point :
+                portfolioReturnCalculator.calculatePortfolioValueSeries(returns, 100.0)) {
+            if (point.date().isBefore(initialDate) || point.date().isEqual(initialDate)) {
                 continue;
             }
-            // returnTotal is already cumulative return in percentage
-            // e.g., returnTotal = 2.5 means 2.5% cumulative return
-            double returnTotalPct = dailyReturn.getReturnTotal().doubleValue();
-            double value = 100.0 + returnTotalPct;
 
             points.add(PortfolioPerformanceResponse.PerformancePoint.builder()
-                    .date(dailyReturn.getReturnDate())
-                    .value(value)
+                    .date(point.date())
+                    .value(point.value())
                     .build());
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,10 @@ batch:
   runner:
     recalculate-weight-used:
       enabled: ${RECALCULATE_WEIGHT_USED_ENABLED:false}  # Enable to recalculate existing weightUsed data
+    portfolio-performance-backfill:
+      enabled: ${PORTFOLIO_PERFORMANCE_BACKFILL_ENABLED:false}  # Enable to backfill missing portfolio daily returns
+    portfolio-return-rebuild:
+      enabled: ${PORTFOLIO_RETURN_REBUILD_ENABLED:false}  # Enable to rebuild incorrect portfolio return history
     ohlc-backfill:
       enabled: ${OHLC_BACKFILL_ENABLED:false}  # Enable to backfill OHLC data from 2025-01-13
 

--- a/src/test/java/com/porcana/domain/portfolio/service/PortfolioReturnCalculatorTest.java
+++ b/src/test/java/com/porcana/domain/portfolio/service/PortfolioReturnCalculatorTest.java
@@ -4,7 +4,6 @@ import com.porcana.domain.portfolio.entity.PortfolioDailyReturn;
 import com.porcana.domain.portfolio.entity.SnapshotAssetDailyReturn;
 import com.porcana.domain.portfolio.repository.PortfolioDailyReturnRepository;
 import com.porcana.domain.portfolio.repository.SnapshotAssetDailyReturnRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,61 +46,63 @@ class PortfolioReturnCalculatorTest {
     class CalculateTotalReturnTest {
 
         @Test
-        @DisplayName("단일 스냅샷 내 여러 일자 - 마지막 날의 누적 수익률만 사용해야 함")
         void singleSnapshot_shouldUseOnlyLastDayReturn() {
-            // Given: 스냅샷 A에 3일치 누적 수익률 데이터
-            // DB에는 매일의 "스냅샷 시작 대비 누적 수익률"이 저장됨
             List<PortfolioDailyReturn> dailyReturns = List.of(
-                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 11), new BigDecimal("2.0")),  // Day 1: 2%
-                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 12), new BigDecimal("5.0")),  // Day 2: 5%
-                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 13), new BigDecimal("10.0")) // Day 3: 10%
+                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 11), new BigDecimal("2.0")),
+                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 12), new BigDecimal("5.0")),
+                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 13), new BigDecimal("10.0"))
             );
 
             when(portfolioDailyReturnRepository.findByPortfolioIdOrderByReturnDateAsc(PORTFOLIO_ID))
                     .thenReturn(dailyReturns);
 
-            // When
             Double result = calculator.calculateTotalReturn(PORTFOLIO_ID);
 
-            // Then: 마지막 날의 누적 수익률 10%만 사용해야 함
-            // 잘못된 계산: (1.02) × (1.05) × (1.10) - 1 = 17.8% (버그)
-            // 올바른 계산: 10% (마지막 날 누적 수익률)
             assertThat(result).isCloseTo(10.0, within(0.01));
         }
 
         @Test
-        @DisplayName("여러 스냅샷 - 각 스냅샷의 마지막 수익률을 복리로 연결")
         void multipleSnapshots_shouldCompoundLastDayOfEachSnapshot() {
-            // Given: 스냅샷 A (10% 수익) → 리밸런싱 → 스냅샷 B (5% 수익)
             List<PortfolioDailyReturn> dailyReturns = List.of(
-                    // Snapshot A
                     createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 11), new BigDecimal("3.0")),
                     createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 12), new BigDecimal("7.0")),
-                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 13), new BigDecimal("10.0")), // 마지막: 10%
-                    // Snapshot B (리밸런싱 후 새 기간)
+                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 13), new BigDecimal("10.0")),
                     createPortfolioDailyReturn(SNAPSHOT_B, LocalDate.of(2026, 3, 14), new BigDecimal("2.0")),
-                    createPortfolioDailyReturn(SNAPSHOT_B, LocalDate.of(2026, 3, 15), new BigDecimal("5.0"))   // 마지막: 5%
+                    createPortfolioDailyReturn(SNAPSHOT_B, LocalDate.of(2026, 3, 15), new BigDecimal("5.0"))
             );
 
             when(portfolioDailyReturnRepository.findByPortfolioIdOrderByReturnDateAsc(PORTFOLIO_ID))
                     .thenReturn(dailyReturns);
 
-            // When
             Double result = calculator.calculateTotalReturn(PORTFOLIO_ID);
 
-            // Then: (1.10) × (1.05) - 1 = 15.5%
             assertThat(result).isCloseTo(15.5, within(0.01));
         }
+    }
+
+    @Nested
+    @DisplayName("calculatePortfolioValueSeries")
+    class CalculatePortfolioValueSeriesTest {
 
         @Test
-        @DisplayName("빈 데이터 - 0% 반환")
-        void emptyData_shouldReturnZero() {
-            when(portfolioDailyReturnRepository.findByPortfolioIdOrderByReturnDateAsc(PORTFOLIO_ID))
-                    .thenReturn(List.of());
+        void multipleSnapshots_shouldKeepChartContinuous() {
+            List<PortfolioDailyReturn> dailyReturns = List.of(
+                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 11), new BigDecimal("3.0")),
+                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 12), new BigDecimal("7.0")),
+                    createPortfolioDailyReturn(SNAPSHOT_A, LocalDate.of(2026, 3, 13), new BigDecimal("10.0")),
+                    createPortfolioDailyReturn(SNAPSHOT_B, LocalDate.of(2026, 3, 14), new BigDecimal("2.0")),
+                    createPortfolioDailyReturn(SNAPSHOT_B, LocalDate.of(2026, 3, 15), new BigDecimal("5.0"))
+            );
 
-            Double result = calculator.calculateTotalReturn(PORTFOLIO_ID);
+            List<PortfolioReturnCalculator.PortfolioValuePoint> result =
+                    calculator.calculatePortfolioValueSeries(dailyReturns, 100.0);
 
-            assertThat(result).isEqualTo(0.0);
+            assertThat(result).hasSize(5);
+            assertThat(result.get(0).value()).isCloseTo(103.0, within(0.01));
+            assertThat(result.get(1).value()).isCloseTo(107.0, within(0.01));
+            assertThat(result.get(2).value()).isCloseTo(110.0, within(0.01));
+            assertThat(result.get(3).value()).isCloseTo(112.2, within(0.01));
+            assertThat(result.get(4).value()).isCloseTo(115.5, within(0.01));
         }
     }
 
@@ -110,56 +111,43 @@ class PortfolioReturnCalculatorTest {
     class CalculateAssetReturnsTest {
 
         @Test
-        @DisplayName("단일 스냅샷 내 여러 일자 - 자산별로 마지막 날 수익률만 사용")
-        void singleSnapshot_shouldUseOnlyLastDayReturnPerAsset() {
-            // Given: 두 자산의 3일치 누적 수익률 데이터
+        void singleSnapshot_shouldUseLatestReturnPerAsset() {
             List<SnapshotAssetDailyReturn> assetReturns = List.of(
-                    // Asset 1: 매일 누적 수익률 증가
                     createAssetDailyReturn(SNAPSHOT_A, ASSET_1, LocalDate.of(2026, 3, 11), new BigDecimal("5.0")),
                     createAssetDailyReturn(SNAPSHOT_A, ASSET_1, LocalDate.of(2026, 3, 12), new BigDecimal("10.0")),
-                    createAssetDailyReturn(SNAPSHOT_A, ASSET_1, LocalDate.of(2026, 3, 13), new BigDecimal("15.0")), // 마지막: 15%
-                    // Asset 2: 하락
+                    createAssetDailyReturn(SNAPSHOT_A, ASSET_1, LocalDate.of(2026, 3, 13), new BigDecimal("15.0")),
                     createAssetDailyReturn(SNAPSHOT_A, ASSET_2, LocalDate.of(2026, 3, 11), new BigDecimal("-2.0")),
                     createAssetDailyReturn(SNAPSHOT_A, ASSET_2, LocalDate.of(2026, 3, 12), new BigDecimal("-3.0")),
-                    createAssetDailyReturn(SNAPSHOT_A, ASSET_2, LocalDate.of(2026, 3, 13), new BigDecimal("-5.0"))  // 마지막: -5%
+                    createAssetDailyReturn(SNAPSHOT_A, ASSET_2, LocalDate.of(2026, 3, 13), new BigDecimal("-5.0"))
             );
 
             when(snapshotAssetDailyReturnRepository.findByPortfolioIdOrderByReturnDateAsc(PORTFOLIO_ID))
                     .thenReturn(assetReturns);
 
-            // When
             Map<UUID, Double> result = calculator.calculateAssetReturns(PORTFOLIO_ID, Set.of(ASSET_1, ASSET_2));
 
-            // Then
             assertThat(result.get(ASSET_1)).isCloseTo(15.0, within(0.01));
             assertThat(result.get(ASSET_2)).isCloseTo(-5.0, within(0.01));
         }
 
         @Test
-        @DisplayName("여러 스냅샷 - 자산별로 각 스냅샷의 마지막 수익률을 복리로 연결")
-        void multipleSnapshots_shouldCompoundLastDayOfEachSnapshotPerAsset() {
-            // Given: 스냅샷 A → 리밸런싱 → 스냅샷 B
+        void rebalance_shouldResetAssetReturnToLatestSnapshot() {
             List<SnapshotAssetDailyReturn> assetReturns = List.of(
-                    // Snapshot A - Asset 1
                     createAssetDailyReturn(SNAPSHOT_A, ASSET_1, LocalDate.of(2026, 3, 11), new BigDecimal("5.0")),
-                    createAssetDailyReturn(SNAPSHOT_A, ASSET_1, LocalDate.of(2026, 3, 12), new BigDecimal("10.0")), // 마지막: 10%
-                    // Snapshot B - Asset 1 (리밸런싱 후)
+                    createAssetDailyReturn(SNAPSHOT_A, ASSET_1, LocalDate.of(2026, 3, 12), new BigDecimal("10.0")),
                     createAssetDailyReturn(SNAPSHOT_B, ASSET_1, LocalDate.of(2026, 3, 14), new BigDecimal("3.0")),
-                    createAssetDailyReturn(SNAPSHOT_B, ASSET_1, LocalDate.of(2026, 3, 15), new BigDecimal("5.0"))   // 마지막: 5%
+                    createAssetDailyReturn(SNAPSHOT_B, ASSET_1, LocalDate.of(2026, 3, 15), new BigDecimal("5.0"))
             );
 
             when(snapshotAssetDailyReturnRepository.findByPortfolioIdOrderByReturnDateAsc(PORTFOLIO_ID))
                     .thenReturn(assetReturns);
 
-            // When
             Map<UUID, Double> result = calculator.calculateAssetReturns(PORTFOLIO_ID, Set.of(ASSET_1));
 
-            // Then: (1.10) × (1.05) - 1 = 15.5%
-            assertThat(result.get(ASSET_1)).isCloseTo(15.5, within(0.01));
+            assertThat(result.get(ASSET_1)).isCloseTo(5.0, within(0.01));
         }
 
         @Test
-        @DisplayName("자산 데이터 없음 - 해당 자산은 0% 반환")
         void noDataForAsset_shouldReturnZero() {
             when(snapshotAssetDailyReturnRepository.findByPortfolioIdOrderByReturnDateAsc(PORTFOLIO_ID))
                     .thenReturn(List.of());
@@ -170,16 +158,15 @@ class PortfolioReturnCalculatorTest {
         }
     }
 
-    // Helper methods
     private PortfolioDailyReturn createPortfolioDailyReturn(UUID snapshotId, LocalDate date, BigDecimal returnTotal) {
         return PortfolioDailyReturn.from(
                 PORTFOLIO_ID,
                 snapshotId,
                 date,
                 returnTotal,
-                returnTotal, // returnLocal = returnTotal for simplicity
-                BigDecimal.ZERO, // returnFx
-                new BigDecimal("10000000") // totalValueKrw
+                returnTotal,
+                BigDecimal.ZERO,
+                new BigDecimal("10000000")
         );
     }
 
@@ -189,12 +176,12 @@ class PortfolioReturnCalculatorTest {
                 snapshotId,
                 assetId,
                 date,
-                new BigDecimal("10.0"), // weightUsed
-                returnTotal, // assetReturnLocal
-                returnTotal, // assetReturnTotal
-                BigDecimal.ZERO, // fxReturn
-                new BigDecimal("1.0"), // contributionTotal
-                new BigDecimal("1000000") // valueKrw
+                new BigDecimal("10.0"),
+                returnTotal,
+                returnTotal,
+                BigDecimal.ZERO,
+                new BigDecimal("1.0"),
+                new BigDecimal("1000000")
         );
     }
 }


### PR DESCRIPTION
## Summary
- keep portfolio performance charts continuous across snapshot changes caused by rebalancing
- reset per-asset displayed returns to the latest snapshot baseline after rebalancing
- extract portfolio performance backfill logic into a shared service and add a dedicated rebuild runner for existing incorrect data

## Runner
- enable atch.runner.portfolio-return-rebuild.enabled=true
- or set PORTFOLIO_RETURN_REBUILD_ENABLED=true
- the runner deletes existing portfolio_daily_returns and snapshot_asset_daily_returns for ACTIVE and FINISHED portfolios, then rebuilds them from snapshots

## Verification
- ./gradlew testClasses
- ./gradlew test --tests " com.porcana.domain.portfolio.service.PortfolioReturnCalculatorTest\

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 포트폴리오 반환 데이터 재구성 기능 추가
  * 포트폴리오 성능 백필 서비스 추가

* **개선사항**
  * 포트폴리오 가치 계산 알고리즘 개선
  * 차트 데이터 계산 방식 최적화
  * 자산 반환 계산 로직 단순화

* **Chores**
  * 배치 실행기 기능 토글 설정 추가

* **Tests**
  * 포트폴리오 반환 계산 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->