### PR TITLE
Feat: add baseline flag to portfolio list

### DIFF
--- a/src/main/java/com/porcana/domain/portfolio/dto/PortfolioListResponse.java
+++ b/src/main/java/com/porcana/domain/portfolio/dto/PortfolioListResponse.java
@@ -1,6 +1,7 @@
 package com.porcana.domain.portfolio.dto;
 
 import com.porcana.domain.portfolio.entity.Portfolio;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +19,8 @@ public class PortfolioListResponse {
     private final String status;
     private final Boolean isMain;
     private final Double totalReturnPct;
+    @Schema(description = "시드 설정(Baseline) 존재 여부")
+    private final Boolean hasBaseline;
     private final LocalDate createdAt;
     private final List<TopAsset> topAssets;
 
@@ -27,16 +30,19 @@ public class PortfolioListResponse {
      * @param portfolio Portfolio entity
      * @param isMain Whether this portfolio is the main portfolio
      * @param totalReturnPct Total return percentage
+     * @param hasBaseline Whether holding baseline exists
      * @param topAssets Top 3 assets by weight
      * @return PortfolioListResponse
      */
-    public static PortfolioListResponse from(Portfolio portfolio, boolean isMain, Double totalReturnPct, List<TopAsset> topAssets) {
+    public static PortfolioListResponse from(Portfolio portfolio, boolean isMain, Double totalReturnPct,
+                                             boolean hasBaseline, List<TopAsset> topAssets) {
         return PortfolioListResponse.builder()
                 .portfolioId(portfolio.getId().toString())
                 .name(portfolio.getName())
                 .status(portfolio.getStatus().name())
                 .isMain(isMain)
                 .totalReturnPct(totalReturnPct)
+                .hasBaseline(hasBaseline)
                 .createdAt(portfolio.getCreatedAt().toLocalDate())
                 .topAssets(topAssets)
                 .build();

--- a/src/main/java/com/porcana/domain/portfolio/repository/PortfolioHoldingBaselineRepository.java
+++ b/src/main/java/com/porcana/domain/portfolio/repository/PortfolioHoldingBaselineRepository.java
@@ -3,6 +3,7 @@ package com.porcana.domain.portfolio.repository;
 import com.porcana.domain.portfolio.entity.PortfolioHoldingBaseline;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,24 +15,25 @@ public interface PortfolioHoldingBaselineRepository extends JpaRepository<Portfo
         PortfolioHoldingBaselineRepositoryCustom {
 
     /**
-     * ?ы듃?대━?ㅼ쓽 Holding Baseline 議고쉶
-     * ?ы듃?대━?ㅻ떦 1媛쒕쭔 議댁옱??(UNIQUE INDEX)
+     * Find the holding baseline for a portfolio.
+     * Each portfolio can have at most one baseline row due to the unique index.
      */
     Optional<PortfolioHoldingBaseline> findByPortfolioId(UUID portfolioId);
 
     /**
-     * ?ы듃?대━?ㅼ쓽 Holding Baseline 議댁옱 ?щ? ?뺤씤
+     * Check whether a portfolio has a holding baseline.
      */
     boolean existsByPortfolioId(UUID portfolioId);
 
     /**
-     * 포트폴리오 목록에서 baseline 존재 포트폴리오 ID를 일괄 조회
+     * Fetch portfolio IDs that already have a holding baseline.
+     * Used by portfolio list APIs to avoid N+1 existence checks.
      */
     @Query("SELECT b.portfolioId FROM PortfolioHoldingBaseline b WHERE b.portfolioId IN :portfolioIds")
-    List<UUID> findPortfolioIdsByPortfolioIdIn(List<UUID> portfolioIds);
+    List<UUID> findPortfolioIdsByPortfolioIdIn(@Param("portfolioIds") List<UUID> portfolioIds);
 
     /**
-     * ?ы듃?대━?ㅼ쓽 Holding Baseline ??젣
+     * Delete the holding baseline for a portfolio.
      */
     void deleteByPortfolioId(UUID portfolioId);
 }

--- a/src/main/java/com/porcana/domain/portfolio/repository/PortfolioHoldingBaselineRepository.java
+++ b/src/main/java/com/porcana/domain/portfolio/repository/PortfolioHoldingBaselineRepository.java
@@ -2,8 +2,10 @@ package com.porcana.domain.portfolio.repository;
 
 import com.porcana.domain.portfolio.entity.PortfolioHoldingBaseline;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,18 +14,24 @@ public interface PortfolioHoldingBaselineRepository extends JpaRepository<Portfo
         PortfolioHoldingBaselineRepositoryCustom {
 
     /**
-     * 포트폴리오의 Holding Baseline 조회
-     * 포트폴리오당 1개만 존재함 (UNIQUE INDEX)
+     * ?ы듃?대━?ㅼ쓽 Holding Baseline 議고쉶
+     * ?ы듃?대━?ㅻ떦 1媛쒕쭔 議댁옱??(UNIQUE INDEX)
      */
     Optional<PortfolioHoldingBaseline> findByPortfolioId(UUID portfolioId);
 
     /**
-     * 포트폴리오의 Holding Baseline 존재 여부 확인
+     * ?ы듃?대━?ㅼ쓽 Holding Baseline 議댁옱 ?щ? ?뺤씤
      */
     boolean existsByPortfolioId(UUID portfolioId);
 
     /**
-     * 포트폴리오의 Holding Baseline 삭제
+     * 포트폴리오 목록에서 baseline 존재 포트폴리오 ID를 일괄 조회
+     */
+    @Query("SELECT b.portfolioId FROM PortfolioHoldingBaseline b WHERE b.portfolioId IN :portfolioIds")
+    List<UUID> findPortfolioIdsByPortfolioIdIn(List<UUID> portfolioIds);
+
+    /**
+     * ?ы듃?대━?ㅼ쓽 Holding Baseline ??젣
      */
     void deleteByPortfolioId(UUID portfolioId);
 }

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -82,13 +82,20 @@ public class PortfolioService {
         }
 
         final UUID finalMainPortfolioId = mainPortfolioId;
+        Set<UUID> portfolioIds = portfolios.stream()
+                .map(Portfolio::getId)
+                .collect(Collectors.toSet());
+        Set<UUID> baselinePortfolioIds = portfolioIds.isEmpty()
+                ? Collections.emptySet()
+                : new HashSet<>(holdingBaselineRepository.findPortfolioIdsByPortfolioIdIn(portfolioIds.stream().toList()));
 
         return portfolios.stream()
                 .map(portfolio -> {
                     Double totalReturnPct = calculateTotalReturn(portfolio.getId());
                     boolean isMain = portfolio.getId().equals(finalMainPortfolioId);
+                    boolean hasBaseline = baselinePortfolioIds.contains(portfolio.getId());
                     List<PortfolioListResponse.TopAsset> topAssets = getTopAssets(portfolio.getId());
-                    return PortfolioListResponse.from(portfolio, isMain, totalReturnPct, topAssets);
+                    return PortfolioListResponse.from(portfolio, isMain, totalReturnPct, hasBaseline, topAssets);
                 })
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## Summary
- add hasBaseline to portfolio list response
- batch-fetch baseline portfolio ids for the list to avoid N+1 queries
- keep existing portfolio list behavior unchanged otherwise

## Verification
- ./gradlew.bat compileJava

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 포트폴리오 목록에 베이스라인 보유 여부(hasBaseline)가 추가되었습니다. 각 포트폴리오가 베이스라인 홀딩 데이터를 보유하고 있는지 바로 확인할 수 있어 관리·분석이 쉬워집니다.
* **개선**
  * 다수 포트폴리오 조회 시 베이스라인 정보 조회 효율이 향상되어 응답 성능이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->