### PR TITLE
Fix portfolio performance baseline timing

### DIFF
--- a/src/main/java/com/porcana/batch/job/PortfolioPerformanceBatchJob.java
+++ b/src/main/java/com/porcana/batch/job/PortfolioPerformanceBatchJob.java
@@ -361,7 +361,9 @@ public class PortfolioPerformanceBatchJob {
     private Optional<AssetReturnResult> calculateAssetReturn(Asset asset, LocalDate startDate, LocalDate targetDate,
                                                              Long jobExecutionId) {
         // Get start price
-        Optional<AssetPrice> startPriceOpt = findClosestPrice(asset, startDate);
+        Optional<AssetPrice> startPriceOpt = startDate.equals(targetDate)
+                ? findClosestPriceBefore(asset, startDate)
+                : findClosestPrice(asset, startDate);
         if (startPriceOpt.isEmpty()) {
             log.warn("No start price found for asset {} on {}", asset.getSymbol(), startDate);
             batchIssueCollector.recordAssetIssue(jobExecutionId, "calculatePortfolioPerformanceStep", asset,
@@ -424,7 +426,9 @@ public class PortfolioPerformanceBatchJob {
      */
     private Optional<BigDecimal> calculateFxReturn(LocalDate startDate, LocalDate targetDate) {
         // Get USD/KRW exchange rate at start date
-        Optional<ExchangeRate> startRateOpt = findClosestExchangeRate(CurrencyCode.USD, startDate);
+        Optional<ExchangeRate> startRateOpt = startDate.equals(targetDate)
+                ? findClosestExchangeRateBefore(CurrencyCode.USD, startDate)
+                : findClosestExchangeRate(CurrencyCode.USD, startDate);
         if (startRateOpt.isEmpty()) {
             log.warn("No USD exchange rate found for start date {}", startDate);
             return Optional.empty();
@@ -476,6 +480,23 @@ public class PortfolioPerformanceBatchJob {
         return Optional.of(prices.get(prices.size() - 1));
     }
 
+    private Optional<AssetPrice> findClosestPriceBefore(Asset asset, LocalDate date) {
+        LocalDate lookbackStart = date.minusDays(7);
+        LocalDate dayBefore = date.minusDays(1);
+        if (dayBefore.isBefore(lookbackStart)) {
+            return Optional.empty();
+        }
+
+        List<AssetPrice> prices = assetPriceRepository.findByAssetAndPriceDateBetweenOrderByPriceDateAsc(
+                asset, lookbackStart, dayBefore);
+
+        if (prices.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(prices.get(prices.size() - 1));
+    }
+
     /**
      * 특정 날짜에 가장 가까운 환율을 찾습니다
      * (정확한 날짜가 없으면 7일 이내 가장 최근 환율 사용)
@@ -501,6 +522,23 @@ public class PortfolioPerformanceBatchJob {
         }
 
         // Return the closest rate (first in descending order)
+        return Optional.of(rates.get(0));
+    }
+
+    private Optional<ExchangeRate> findClosestExchangeRateBefore(CurrencyCode currencyCode, LocalDate date) {
+        LocalDate lookbackStart = date.minusDays(7);
+        LocalDate dayBefore = date.minusDays(1);
+        if (dayBefore.isBefore(lookbackStart)) {
+            return Optional.empty();
+        }
+
+        List<ExchangeRate> rates = exchangeRateRepository.findByCurrencyCodeAndExchangeDateBetweenOrderByExchangeDateDesc(
+                currencyCode, lookbackStart, dayBefore);
+
+        if (rates.isEmpty()) {
+            return Optional.empty();
+        }
+
         return Optional.of(rates.get(0));
     }
 

--- a/src/main/java/com/porcana/domain/home/service/HomeService.java
+++ b/src/main/java/com/porcana/domain/home/service/HomeService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class HomeService {
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     private final UserRepository userRepository;
     private final PortfolioRepository portfolioRepository;
@@ -190,7 +192,7 @@ public class HomeService {
         // Get the latest snapshot
         Optional<PortfolioSnapshot> latestSnapshotOpt = portfolioSnapshotRepository
                 .findFirstByPortfolioIdAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
-                        portfolioId, LocalDate.now());
+                        portfolioId, todayInSeoul());
 
         if (latestSnapshotOpt.isEmpty()) {
             return weights; // No snapshot yet, will fallback to PortfolioAsset weights
@@ -236,6 +238,10 @@ public class HomeService {
         return portfolioReturnCalculator.calculateAssetReturns(portfolioId, assetIds);
     }
 
+    private LocalDate todayInSeoul() {
+        return LocalDate.now(SEOUL);
+    }
+
     /**
      * Get snapshot target weights for assets
      * Returns the weights set in the latest snapshot (target/initial allocation)
@@ -246,7 +252,7 @@ public class HomeService {
         // Get the latest snapshot
         Optional<PortfolioSnapshot> latestSnapshotOpt = portfolioSnapshotRepository
                 .findFirstByPortfolioIdAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
-                        portfolioId, LocalDate.now());
+                        portfolioId, todayInSeoul());
 
         if (latestSnapshotOpt.isEmpty()) {
             return weights;

--- a/src/main/java/com/porcana/domain/portfolio/entity/Portfolio.java
+++ b/src/main/java/com/porcana/domain/portfolio/entity/Portfolio.java
@@ -133,9 +133,13 @@ public class Portfolio {
     }
 
     public void start() {
+        start(LocalDate.now());
+    }
+
+    public void start(LocalDate startedAt) {
         if (this.status == PortfolioStatus.DRAFT) {
             this.status = PortfolioStatus.ACTIVE;
-            this.startedAt = LocalDate.now();
+            this.startedAt = startedAt;
         }
         // If already ACTIVE or FINISHED, do nothing (idempotent)
     }
@@ -175,11 +179,15 @@ public class Portfolio {
      * Activate the portfolio (DRAFT -> ACTIVE)
      */
     public void activate() {
+        activate(LocalDate.now());
+    }
+
+    public void activate(LocalDate startedAt) {
         if (this.status != PortfolioStatus.DRAFT) {
             throw new IllegalStateException("Only DRAFT portfolios can be activated");
         }
         this.status = PortfolioStatus.ACTIVE;
-        this.startedAt = LocalDate.now();
+        this.startedAt = startedAt;
     }
 
     // ========== Aggregate Root: 하위 엔티티 생성 ==========

--- a/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/porcana/domain/portfolio/service/PortfolioService.java
@@ -210,7 +210,7 @@ public class PortfolioService {
         Portfolio saved = portfolioRepository.save(portfolio);
 
         // 자산 추가 (DDD: Portfolio가 PortfolioAsset 생성)
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate today = todayInSeoul();
         for (DirectCreatePortfolioCommand.AssetWeight asset : assets) {
             PortfolioAsset portfolioAsset = saved.addAsset(asset.getAssetId(), weightMap.get(asset.getAssetId()));
             portfolioAssetRepository.save(portfolioAsset);
@@ -227,7 +227,7 @@ public class PortfolioService {
         }
 
         // ACTIVE 상태로 변경
-        saved.activate();
+        saved.activate(today);
         portfolioRepository.save(saved);
 
         return CreatePortfolioResponse.from(saved);
@@ -281,7 +281,7 @@ public class PortfolioService {
             throw new IllegalStateException("Portfolio is already started");
         }
 
-        portfolio.start();
+        portfolio.start(todayInSeoul());
         Portfolio saved = portfolioRepository.save(portfolio);
         return StartPortfolioResponse.from(saved);
     }
@@ -311,7 +311,7 @@ public class PortfolioService {
     }
 
     private PortfolioPerformanceResponse buildPortfolioPerformance(Portfolio portfolio, String range) {
-        LocalDate endDate = LocalDate.now();
+        LocalDate endDate = todayInSeoul();
         LocalDate startDate = calculateStartDate(endDate, range);
 
         List<PortfolioDailyReturn> returns = portfolioDailyReturnRepository
@@ -416,7 +416,7 @@ public class PortfolioService {
         // Get the latest snapshot
         Optional<PortfolioSnapshot> latestSnapshotOpt = portfolioSnapshotRepository
                 .findFirstByPortfolioIdAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
-                        portfolioId, LocalDate.now());
+                        portfolioId, todayInSeoul());
 
         if (latestSnapshotOpt.isEmpty()) {
             return weights; // No snapshot yet, will fallback to PortfolioAsset weights
@@ -468,7 +468,7 @@ public class PortfolioService {
         // Get the latest snapshot
         Optional<PortfolioSnapshot> latestSnapshotOpt = portfolioSnapshotRepository
                 .findFirstByPortfolioIdAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(
-                        portfolioId, LocalDate.now());
+                        portfolioId, todayInSeoul());
 
         if (latestSnapshotOpt.isEmpty()) {
             return weights;
@@ -797,7 +797,7 @@ public class PortfolioService {
         }
 
         // Create snapshot for the weight update
-        LocalDate today = LocalDate.now();
+        LocalDate today = todayInSeoul();
         Map<UUID, BigDecimal> weightMap = command.getWeights().stream()
                 .collect(Collectors.toMap(
                         UpdateAssetWeightsCommand.AssetWeightUpdate::getAssetId,
@@ -844,6 +844,10 @@ public class PortfolioService {
             case "1Y" -> endDate.minusYears(1);
             default -> endDate.minusMonths(1);
         };
+    }
+
+    private LocalDate todayInSeoul() {
+        return LocalDate.now(SEOUL);
     }
 
     /**
@@ -916,7 +920,7 @@ public class PortfolioService {
      */
     private Map<UUID, Double> getDeckLatestWeights(UUID portfolioId, Set<UUID> assetIds) {
         Optional<PortfolioSnapshot> latestSnapshot = portfolioSnapshotRepository
-                .findFirstByPortfolioIdAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(portfolioId, LocalDate.now());
+                .findFirstByPortfolioIdAndEffectiveDateLessThanEqualOrderByEffectiveDateDesc(portfolioId, todayInSeoul());
 
         if (latestSnapshot.isEmpty()) {
             return Map.of();

--- a/src/test/java/com/porcana/batch/job/PortfolioPerformanceBatchJobTest.java
+++ b/src/test/java/com/porcana/batch/job/PortfolioPerformanceBatchJobTest.java
@@ -1,0 +1,212 @@
+package com.porcana.batch.job;
+
+import com.porcana.batch.listener.BatchNotificationListener;
+import com.porcana.batch.support.BatchIssueCollector;
+import com.porcana.domain.asset.AssetPriceRepository;
+import com.porcana.domain.asset.AssetRepository;
+import com.porcana.domain.asset.entity.Asset;
+import com.porcana.domain.asset.entity.AssetPrice;
+import com.porcana.domain.exchangerate.ExchangeRateRepository;
+import com.porcana.domain.exchangerate.entity.CurrencyCode;
+import com.porcana.domain.exchangerate.entity.ExchangeRate;
+import com.porcana.domain.portfolio.repository.PortfolioDailyReturnRepository;
+import com.porcana.domain.portfolio.repository.PortfolioRepository;
+import com.porcana.domain.portfolio.repository.PortfolioSnapshotAssetRepository;
+import com.porcana.domain.portfolio.repository.PortfolioSnapshotRepository;
+import com.porcana.domain.portfolio.repository.SnapshotAssetDailyReturnRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PortfolioPerformanceBatchJobTest {
+
+    @Mock private JobRepository jobRepository;
+    @Mock private PlatformTransactionManager transactionManager;
+    @Mock private PortfolioRepository portfolioRepository;
+    @Mock private PortfolioSnapshotRepository snapshotRepository;
+    @Mock private PortfolioSnapshotAssetRepository snapshotAssetRepository;
+    @Mock private AssetRepository assetRepository;
+    @Mock private AssetPriceRepository assetPriceRepository;
+    @Mock private ExchangeRateRepository exchangeRateRepository;
+    @Mock private PortfolioDailyReturnRepository dailyReturnRepository;
+    @Mock private SnapshotAssetDailyReturnRepository assetDailyReturnRepository;
+    @Mock private BatchNotificationListener batchNotificationListener;
+    @Mock private BatchIssueCollector batchIssueCollector;
+
+    @Test
+    @DisplayName("첫 수익률 계산은 스냅샷 당일이 아니라 직전 가격을 시작가로 사용한다")
+    void calculateAssetReturn_usesPreviousPriceWhenSnapshotStartsSameDay() {
+        PortfolioPerformanceBatchJob job = new PortfolioPerformanceBatchJob(
+                jobRepository,
+                transactionManager,
+                portfolioRepository,
+                snapshotRepository,
+                snapshotAssetRepository,
+                assetRepository,
+                assetPriceRepository,
+                exchangeRateRepository,
+                dailyReturnRepository,
+                assetDailyReturnRepository,
+                batchNotificationListener,
+                batchIssueCollector
+        );
+
+        Asset asset = Asset.builder()
+                .market(Asset.Market.KR)
+                .symbol("005930")
+                .name("Samsung Electronics")
+                .type(Asset.AssetType.STOCK)
+                .active(true)
+                .asOf(LocalDate.of(2026, 4, 29))
+                .build();
+
+        AssetPrice previousPrice = AssetPrice.builder()
+                .asset(asset)
+                .priceDate(LocalDate.of(2026, 4, 28))
+                .openPrice(new BigDecimal("100"))
+                .highPrice(new BigDecimal("100"))
+                .lowPrice(new BigDecimal("100"))
+                .closePrice(new BigDecimal("100"))
+                .volume(1L)
+                .build();
+
+        AssetPrice targetPrice = AssetPrice.builder()
+                .asset(asset)
+                .priceDate(LocalDate.of(2026, 4, 29))
+                .openPrice(new BigDecimal("110"))
+                .highPrice(new BigDecimal("110"))
+                .lowPrice(new BigDecimal("110"))
+                .closePrice(new BigDecimal("110"))
+                .volume(1L)
+                .build();
+
+        when(assetPriceRepository.findByAssetAndPriceDate(asset, LocalDate.of(2026, 4, 29)))
+                .thenReturn(Optional.of(targetPrice));
+        when(assetPriceRepository.findByAssetAndPriceDateBetweenOrderByPriceDateAsc(
+                asset,
+                LocalDate.of(2026, 4, 22),
+                LocalDate.of(2026, 4, 28)
+        )).thenReturn(List.of(previousPrice));
+
+        Optional<?> result = ReflectionTestUtils.invokeMethod(
+                job,
+                "calculateAssetReturn",
+                asset,
+                LocalDate.of(2026, 4, 29),
+                LocalDate.of(2026, 4, 29),
+                1L
+        );
+
+        assertThat(result).isPresent();
+        Object assetReturn = result.orElseThrow();
+        BigDecimal totalReturn = (BigDecimal) ReflectionTestUtils.invokeMethod(assetReturn, "assetReturnTotal");
+        assertThat(totalReturn).isEqualByComparingTo("10.000000");
+    }
+
+    @Test
+    @DisplayName("미국 자산 첫 수익률 계산은 환율도 직전 값을 시작점으로 사용한다")
+    void calculateAssetReturn_usesPreviousFxRateWhenSnapshotStartsSameDay() {
+        PortfolioPerformanceBatchJob job = new PortfolioPerformanceBatchJob(
+                jobRepository,
+                transactionManager,
+                portfolioRepository,
+                snapshotRepository,
+                snapshotAssetRepository,
+                assetRepository,
+                assetPriceRepository,
+                exchangeRateRepository,
+                dailyReturnRepository,
+                assetDailyReturnRepository,
+                batchNotificationListener,
+                batchIssueCollector
+        );
+
+        Asset asset = Asset.builder()
+                .market(Asset.Market.US)
+                .symbol("AAPL")
+                .name("Apple")
+                .type(Asset.AssetType.STOCK)
+                .active(true)
+                .asOf(LocalDate.of(2026, 4, 29))
+                .build();
+
+        AssetPrice previousPrice = AssetPrice.builder()
+                .asset(asset)
+                .priceDate(LocalDate.of(2026, 4, 28))
+                .openPrice(new BigDecimal("100"))
+                .highPrice(new BigDecimal("100"))
+                .lowPrice(new BigDecimal("100"))
+                .closePrice(new BigDecimal("100"))
+                .volume(1L)
+                .build();
+
+        AssetPrice targetPrice = AssetPrice.builder()
+                .asset(asset)
+                .priceDate(LocalDate.of(2026, 4, 29))
+                .openPrice(new BigDecimal("110"))
+                .highPrice(new BigDecimal("110"))
+                .lowPrice(new BigDecimal("110"))
+                .closePrice(new BigDecimal("110"))
+                .volume(1L)
+                .build();
+
+        ExchangeRate previousRate = ExchangeRate.builder()
+                .currencyCode(CurrencyCode.USD)
+                .currencyName("US Dollar")
+                .baseRate(new BigDecimal("1300"))
+                .exchangeDate(LocalDate.of(2026, 4, 28))
+                .build();
+
+        ExchangeRate targetRate = ExchangeRate.builder()
+                .currencyCode(CurrencyCode.USD)
+                .currencyName("US Dollar")
+                .baseRate(new BigDecimal("1326"))
+                .exchangeDate(LocalDate.of(2026, 4, 29))
+                .build();
+
+        when(assetPriceRepository.findByAssetAndPriceDate(asset, LocalDate.of(2026, 4, 29)))
+                .thenReturn(Optional.of(targetPrice));
+        when(assetPriceRepository.findByAssetAndPriceDateBetweenOrderByPriceDateAsc(
+                asset,
+                LocalDate.of(2026, 4, 22),
+                LocalDate.of(2026, 4, 28)
+        )).thenReturn(List.of(previousPrice));
+        when(exchangeRateRepository.findByCurrencyCodeAndExchangeDate(CurrencyCode.USD, LocalDate.of(2026, 4, 29)))
+                .thenReturn(Optional.of(targetRate));
+        when(exchangeRateRepository.findByCurrencyCodeAndExchangeDateBetweenOrderByExchangeDateDesc(
+                CurrencyCode.USD,
+                LocalDate.of(2026, 4, 22),
+                LocalDate.of(2026, 4, 28)
+        )).thenReturn(List.of(previousRate));
+
+        Optional<?> result = ReflectionTestUtils.invokeMethod(
+                job,
+                "calculateAssetReturn",
+                asset,
+                LocalDate.of(2026, 4, 29),
+                LocalDate.of(2026, 4, 29),
+                1L
+        );
+
+        assertThat(result).isPresent();
+        Object assetReturn = result.orElseThrow();
+        BigDecimal fxReturn = (BigDecimal) ReflectionTestUtils.invokeMethod(assetReturn, "fxReturn");
+        BigDecimal totalReturn = (BigDecimal) ReflectionTestUtils.invokeMethod(assetReturn, "assetReturnTotal");
+        assertThat(fxReturn).isEqualByComparingTo("2.000000");
+        assertThat(totalReturn).isEqualByComparingTo("12.000000");
+    }
+}

--- a/src/test/java/com/porcana/domain/portfolio/service/HoldingBaselineServiceTest.java
+++ b/src/test/java/com/porcana/domain/portfolio/service/HoldingBaselineServiceTest.java
@@ -1,0 +1,105 @@
+package com.porcana.domain.portfolio.service;
+
+import com.porcana.domain.asset.AssetPriceRepository;
+import com.porcana.domain.asset.AssetRepository;
+import com.porcana.domain.asset.entity.Asset;
+import com.porcana.domain.asset.entity.AssetPrice;
+import com.porcana.domain.exchangerate.ExchangeRateRepository;
+import com.porcana.domain.exchangerate.entity.CurrencyCode;
+import com.porcana.domain.exchangerate.entity.ExchangeRate;
+import com.porcana.domain.portfolio.dto.PortfolioDetailResponse;
+import com.porcana.domain.portfolio.entity.PortfolioHoldingBaseline;
+import com.porcana.domain.portfolio.repository.PortfolioAssetRepository;
+import com.porcana.domain.portfolio.repository.PortfolioHoldingBaselineRepository;
+import com.porcana.domain.portfolio.repository.PortfolioRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HoldingBaselineServiceTest {
+
+    @Mock private PortfolioRepository portfolioRepository;
+    @Mock private PortfolioAssetRepository portfolioAssetRepository;
+    @Mock private PortfolioHoldingBaselineRepository baselineRepository;
+    @Mock private AssetRepository assetRepository;
+    @Mock private AssetPriceRepository assetPriceRepository;
+    @Mock private ExchangeRateRepository exchangeRateRepository;
+
+    @InjectMocks
+    private HoldingBaselineService holdingBaselineService;
+
+    @Test
+    @DisplayName("잔금이 남아 있어도 가격 변동이 없으면 baseline profit은 0이다")
+    void getBaselineSummaryInternal_doesNotTreatCashAsProfit() {
+        UUID portfolioId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID assetId = UUID.randomUUID();
+
+        PortfolioHoldingBaseline baseline = PortfolioHoldingBaseline.create(
+                portfolioId,
+                userId,
+                PortfolioHoldingBaseline.SourceType.SEEDED,
+                PortfolioHoldingBaseline.Currency.KRW,
+                new BigDecimal("1000"),
+                "seed"
+        );
+        baseline.addItem(assetId, new BigDecimal("10"), new BigDecimal("100"), new BigDecimal("50"));
+
+        Asset asset = Asset.builder()
+                .market(Asset.Market.KR)
+                .symbol("005930")
+                .name("Samsung Electronics")
+                .type(Asset.AssetType.STOCK)
+                .active(true)
+                .asOf(LocalDate.of(2026, 4, 30))
+                .build();
+        ReflectionTestUtils.setField(asset, "id", assetId);
+
+        AssetPrice latestPrice = AssetPrice.builder()
+                .asset(asset)
+                .priceDate(LocalDate.of(2026, 4, 30))
+                .openPrice(new BigDecimal("100"))
+                .highPrice(new BigDecimal("100"))
+                .lowPrice(new BigDecimal("100"))
+                .closePrice(new BigDecimal("100"))
+                .volume(1L)
+                .build();
+
+        ExchangeRate latestRate = ExchangeRate.builder()
+                .currencyCode(CurrencyCode.USD)
+                .currencyName("US Dollar")
+                .baseRate(new BigDecimal("1300"))
+                .exchangeDate(LocalDate.of(2026, 4, 30))
+                .build();
+
+        when(baselineRepository.findByPortfolioIdWithItems(portfolioId)).thenReturn(Optional.of(baseline));
+        when(exchangeRateRepository.findTopByCurrencyCodeOrderByExchangeDateDesc(CurrencyCode.USD))
+                .thenReturn(Optional.of(latestRate));
+        when(assetRepository.findAllById(List.of(assetId))).thenReturn(List.of(asset));
+        when(assetPriceRepository.findLatestPricesByAssetIds(List.of(assetId))).thenReturn(List.of(latestPrice));
+
+        PortfolioDetailResponse.BaselineSummary summary =
+                holdingBaselineService.getBaselineSummaryInternal(portfolioId);
+
+        assertThat(summary).isNotNull();
+        assertThat(summary.getCashAmount()).isEqualByComparingTo("1000");
+        assertThat(summary.getSeedMoney()).isEqualByComparingTo("2000");
+        assertThat(summary.getTotalValue()).isEqualByComparingTo("2000");
+        assertThat(summary.getProfitAmount()).isEqualByComparingTo("0");
+        assertThat(summary.getProfitPct()).isEqualTo(0.0);
+    }
+}


### PR DESCRIPTION
## Summary
- use previous price and FX data when the first portfolio performance calculation runs on the snapshot effective date
- align portfolio and home snapshot date lookups to Asia/Seoul consistently
- add regression tests for first-day performance calculation and baseline cash handling

## Testing
- `./gradlew testClasses`
- `./gradlew test --tests com.porcana.batch.job.PortfolioPerformanceBatchJobTest --tests com.porcana.domain.portfolio.service.HoldingBaselineServiceTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 포트폴리오 스냅샷 시작 날짜와 대상 날짜가 동일한 경우 수익률 계산 정확성 개선
  * 서울 시간대 기준으로 날짜 계산을 통일하여 시간대 관련 이슈 해결

* **테스트**
  * 배치 작업 및 보유 자산 기준선 서비스 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->